### PR TITLE
Fixed broken Jupyter notebook pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This template codifies LINCC-Framework's best practices for python code organiza
 5) Provide answers to the prompts
 6) Enjoy pure, uncut euphoria.
 
-## Post-euphoria {#post-euphoria}
+## Post-euphoria - Install your new package
 
 Ok, ok, calm down. I know, it's really great. 
 You should go ahead and install your new project using these instructions:
@@ -52,7 +52,7 @@ Notice that this template contains a `.github/workflows` directory with a `pytho
 ### Pre-commit is part of it too
 
 Once you have created a new project from the template, and start coding, you can save yourself from the embarassment of say, not including a blank line at the end of your .py file, by using pre-commit checks.
-After you have successfully run `pip install '.[dev]'` as part of the [post-euphoria](#post-euphoria) step, run `pre-commit install`.
+After you have successfully run `pip install '.[dev]'` as part of the "Post-euphoria - Install your new package" step, run `pre-commit install`.
 This will register all the pre-commit git hooks defined in .pre-commit-config.yaml with git so that they are run before a `git commit` is completed.
 
 This functionality relies on a the third-party tool, [pre-commit](https://pre-commit.com/). It's a very useful tool when paired with Github workflows. Since the workflows will typically prevent code merging if certain tests fail, by using pre-commit, the user can verify that their code will pass all the workflow checks prior to completing a git commit.

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -16,14 +16,15 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "ipykernel"
+    "ipykernel", # Support for Jupyter notebooks
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pre-commit"
+    "pre-commit", # Used to run checks before finalizing a git commit
+    "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
 ]
 
 [build-system]

--- a/{{project_name}}/src/{{module_name}}/__init__.py
+++ b/{{project_name}}/src/{{module_name}}/__init__.py
@@ -1,1 +1,0 @@
-from .version import __version__


### PR DESCRIPTION
Added dev dependency so that the pre-commit hook to remove Jupyter notebook output works as expected. Also, small edit to README, and added justification comments to the pyproject.toml list of dependencies.