### PR TITLE
Issue/17/basic automated template testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ main ]
 
-# Extra context is a way to override options that the user normally
-# specifies during the questions phase of the cookiecutter setup. The keys
-# being overridden here must exist in the cookiecutter.json
-# See https://cookiecutter.readthedocs.io/en/0.9.1/advanced_usage.html#injecting-extra-context
 jobs:
   tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
         include:
 
           - name: Base example
@@ -34,7 +33,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.10'
     - name: Install Python dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI for Template
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Extra context is a way to override options that the user normally
+# specifies during the questions phase of the cookiecutter setup. The keys
+# being overridden here must exist in the cookiecutter.json
+# See https://cookiecutter.readthedocs.io/en/0.9.1/advanced_usage.html#injecting-extra-context
+jobs:
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+
+          - name: Base example
+            extra_flags: ''
+            foldername: 'base_example'
+
+          - name: Provide non-default answers
+            extra_flags: '--data project_name=new_science --data module_name=drewtonian --data author_name=Drew --data author_email=ao@aol.com'
+            foldername: 'non_default_answers'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install Python dependencies
+      run: |
+        sudo apt-get update
+        python -m pip install --upgrade pip
+        pip install .
+        pip install .[dev]
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install copier
+    - name: Generate package
+      run: |
+        copier --defaults ${{ matrix.extra_flags }} copy ./ ../test/${{ matrix.foldername }}
+        cd ../test/${{ matrix.foldername }}
+        cat .copier-answers.yml
+    - name: Code style checks
+      run: |
+        cd ../test/${{ matrix.foldername }}
+        python -m pylint --recursive=y ./src/
+    - name: Build docs
+      run: |
+        cd ../test/${{ matrix.foldername }}
+        cd docs
+        make html
+    - name: Tests
+      run: |
+        cd ../test/${{ matrix.foldername }}
+        cd tests;
+        python -m pytest *

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,17 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .
-        pip install .[dev]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install copier
     - name: Generate package
       run: |
-        copier --defaults ${{ matrix.extra_flags }} copy ./ ../test/${{ matrix.foldername }}
+        copier --vcs-ref HEAD --defaults ${{ matrix.extra_flags }} copy ./ ../test/${{ matrix.foldername }}
         cd ../test/${{ matrix.foldername }}
         cat .copier-answers.yml
+    - name: Build package
+      run: |
+        cd ../test/${{ matrix.foldername }}
+        pip install -e .
+        pip install .[dev]
     - name: Code style checks
       run: |
         cd ../test/${{ matrix.foldername }}
@@ -54,8 +56,7 @@ jobs:
     - name: Build docs
       run: |
         cd ../test/${{ matrix.foldername }}
-        cd docs
-        make html
+        sphinx-build -b html docs/source docs/build/html
     - name: Tests
       run: |
         cd ../test/${{ matrix.foldername }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,4 @@ jobs:
     - name: Tests
       run: |
         cd ../test/${{ matrix.foldername }}
-        cd tests;
-        python -m pytest *
+        python -m pytest tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        python-version: ['3.8', '3.9', '3.10']
         include:
 
           - name: Base example
@@ -33,7 +34,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
       run: |
         sudo apt-get update

--- a/copier.yml
+++ b/copier.yml
@@ -1,6 +1,7 @@
 project_name:
     type: str
     help: What is the name of your project?
+    default: example_project
 
 module_name:
     type: str
@@ -11,10 +12,12 @@ author_name:
     type: str
     help: Your first and last name?
     placeholder: Jenny Fantastic
+    default: Name Placeholder
 
 author_email:
     type: str
     help: Your preferred email address?
+    default: email.placeholder@someplace.special
 
 ###
 # Below this line are Copier configuration options.

--- a/python-project-template/docs/requirements.txt
+++ b/python-project-template/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==6.1.3
+sphinx==5.3.0
 sphinx_rtd_theme==1.1.1

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -27,7 +27,7 @@ dev = [
     "pre-commit", # Used to run checks before finalizing a git commit
     "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
     "pylint", # Used for static linting of files
-    "sphinx==6.1.3", # Used to automatically generate documentation
+    "sphinx==5.3.0", # Used to automatically generate documentation
     "sphinx_rtd_theme==1.1.1", # Used to render documentation
 ]
 


### PR DESCRIPTION
Added a github workflow that _should_:
- Render the template
- Pip install the rendered template
- Run pylint on the rendered template
- Build docs for the rendered template
- Run the unittests in the rendered template

Also added some default answers to questions to make it easier to get started (and to test), and fixed a version number conflict between Sphinx and sphinx-rtd-theme.