### PR TITLE
Incorporating setuptools_scm to support programmatic version information

### DIFF
--- a/python-project-template/.gitignore
+++ b/python-project-template/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # vscode
 .vscode/
+
+# dask
+dask-worker-space/

--- a/python-project-template/.pre-commit-config.yaml
+++ b/python-project-template/.pre-commit-config.yaml
@@ -11,7 +11,11 @@ repos:
         language: system
         entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
 
-    # Run unit tests, verify that they pass
+    # Run unit tests, verify that they pass. Note that coverage is run against
+    # the ./src directory here because that is what will be committed. In the 
+    # github workflow script, the coverage is run against the installed package
+    # and uploaded to Codecov by calling pytest like so:
+    # `python -m pytest --cov=<package_name> --cov-report=xml`
   - repo: local
     hooks:
       - id: pytest-check

--- a/python-project-template/docs/conf.py.jinja
+++ b/python-project-template/docs/conf.py.jinja
@@ -8,6 +8,7 @@ import os
 import sys
 
 import autoapi
+from importlib.metadata import version
 
 # Define path to the code to be documented **relative to where conf.py (this file) is kept**
 sys.path.insert(0, os.path.abspath('../src/'))
@@ -18,7 +19,9 @@ sys.path.insert(0, os.path.abspath('../src/'))
 project = '{{project_name}}'
 copyright = '2023, {{author_name}}'
 author = '{{author_name}}'
-release = 'v0.1'
+release = version('{{project_name}}')
+# for example take major/minor
+version = '.'.join(release.split('.')[:2])
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/python-project-template/docs/index.rst.jinja
+++ b/python-project-template/docs/index.rst.jinja
@@ -1,5 +1,4 @@
-.. {{module_name}} documentation master file, created by
-   sphinx-quickstart on Thu Feb  2 12:58:01 2023.
+.. {{module_name}} documentation main file.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -33,8 +33,14 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools","wheel"]
+requires = [
+    "setuptools>=45", # Used to build and package the Python project
+    "setuptools_scm>=6.2", # Gets release version from git. Makes it available programmatically
+]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/{{module_name}}/_version.py"
 
 [tool.pylint.'MESSAGES CONTROL']
 disable = """


### PR DESCRIPTION
*Primary changes*
- Added setuptools_scm for version support.
- Using version information for sphinx build.

*Scope creep*
- Added dask section to .gitignore
- Added comment to .pre-commit-config.yaml to explain why pytest coverage is different when running locally compared to running in CI