### PR TITLE
Separated linting from the rest of the CI workflow.

### DIFF
--- a/python-project-template/.github/workflows/linting.yml.jinja
+++ b/python-project-template/.github/workflows/linting.yml.jinja
@@ -11,18 +11,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10']
-
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -30,11 +25,6 @@ jobs:
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Run unit tests with pytest
-      run: |
-        python -m pytest tests --cov={{module_name}} --cov-report=xml
-    - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v3
-    - name: Analyze code with pylint
+    - name: Analyze code with linter
       run: |
         pylint -rn -sn --recursive=y ./src

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
+      uses: actions/setup-python@v4
+      with:
+        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        python -m pip install --upgrade pip
+        pip install .
+        pip install .[dev]
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run unit tests with pytest
+      run: |
+        python -m pytest tests --cov={{module_name}} --cov-report=xml
+    - name: Upload coverage report to codecov
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
- Pulled the linting step out of the original CI script and dropped it into a distinct `linting.yml` file. 
- Renamed the "python-project" CI script to be "testing-and-coverage.yml".