### PR TITLE
Adding pre-commit hook to prevent committing large files

### DIFF
--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -33,6 +33,10 @@ repos:
       - id: no-commit-to-branch
         name: Don't commit to main or master branch
         description: Prevent the user from committing directly to the primary branch.
+      - id: check-added-large-files
+        name: Check for large files
+        description: Prevent the user from committing very large files.
+        args: ['--maxkb=500']
 
     # verify that pyproject.toml is well formed
   - repo: https://github.com/abravalheri/validate-pyproject


### PR DESCRIPTION
More docs can be found here about this hook: https://github.com/pre-commit/pre-commit-hooks#check-added-large-files

Seems like it plays nicely with git-lfs by ignoring anything tracked by git-lfs.

Currently set to 500kb limit, and of course the user has control over this. They can either change the pre-commit argument from `-maxkb=500` to whatever they want, or ignore the warning with `git commit -m '...' --no-verify`.