### PR TITLE
Update smoke-test.yml

### DIFF
--- a/python-project-template/.github/workflows/smoke-test.yml
+++ b/python-project-template/.github/workflows/smoke-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
Originally smoke-test.yml was created as a `.jinja` file which required that any tokens in the file that used `{` or `}` be escaped with `{% raw %}` and `{% endraw %}`, and those escape sequences would be removed after jinja finished hydrating the template.

However, now that smoke-test.yml is not called "smoke-test.yml.jinja" in the template, jinja will not attempt any replacement, and will not remove the raw/endraw tokens. And the presence of those tokens results in malformed yaml, and therefore the smoke test will fail before it runs in GitHub. 

This PR removes the raw/endraw tokens to create a syntactically correct file. 

