### PR TITLE
Remove extra vertical space

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -7,11 +7,11 @@ authors = [
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
-{% if project_license == 'MIT' %}
+{%- if project_license == 'MIT' %}
     "License :: OSI Approved :: MIT License",
-{% elif project_license == 'BSD' %}
+{%- elif project_license == 'BSD' %}
     "License :: OSI Approved :: BSD License",
-{% endif %}
+{%- endif %}
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Use the vertical white space control `{%-` to remove extra blank lines in the classifiers list.

Extra jinja documentation about this here: https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control