### PR TITLE
Added to the list of excluded dirs/files.

### DIFF
--- a/python-project-template/docs/conf.py.jinja
+++ b/python-project-template/docs/conf.py.jinja
@@ -34,7 +34,7 @@ extensions.append("nbsphinx")
 {%- endif %}
 
 templates_path = []
-exclude_patterns = []
+exclude_patterns = ['_build', '**.ipynb_checkpoints']
 
 master_doc = "index"  # This assumes that sphinx-build is called from the root directory
 html_show_sourcelink = False  # Remove 'view source code' from top of page (for html, not python)


### PR DESCRIPTION
### What the PR does
This PR adds two elements to the `exclude_patterns` list. 

1. `_build` - this will prevent nbsphinx, or any Sphinx-related tool from looking in the `.../docs/_build` directory for .rst files or notebooks that need to be rendered.
2. `**.ipynb_checkpoints` - this will prevent nbsphinx from attempting to render checkpoint files. 

Both of these are recommended in the [Sphinx setup section](https://nbsphinx.readthedocs.io/en/0.2.15/usage.html#Sphinx-Setup) for nbsphinx. 

They are also shown in this example conf.py file for Sphinx: https://nbsphinx.readthedocs.io/en/0.2.15/conf.py

### Why the PR does it
Adding these strings to the `exclude_patterns` list addresses the problem seen when the user rebuilds the documentation multiple times and ends up with an unexpected nesting of directories under the `.../docs/_build` directory which, after more than 2 rebuilds of the documentation, results in nesting in the `.../_readthedocs/html/_build` directory as well. 
