### PR TITLE
Updating CI to cover nondefault options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,55 +16,79 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         copier_config:
           - name: Base example
-            module_name: example_project #The default module_name
+            module_name: example_project # The default module_name
             extra_flags: ''
             foldername: base_example
           - name: Provide non-default answers
             module_name: 'drewtonian' # Same module name provided in `extra_flags` on the next line.
-            extra_flags: '--data project_name=new_science --data module_name=drewtonian --data author_name=Drew --data author_email=ao@aol.com'
+            extra_flags: >-
+              --data project_name=new_science
+              --data module_name=drewtonian
+              --data author_name=Drew
+              --data author_email=ao@aol.com
+              --data project_license=BSD
+              --data preferred_linter=black
+              --data use_isort=false
+              --data mypy_type_checking=basic
+              --data create_example_module=no
+              --data include_notebooks=no
+              --data use_gitlfs=disabled
             foldername: 'non_default_answers'
-
+            
     steps:
+    
     - name: Checkout code
       uses: actions/checkout@v3
+      
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    
     - name: Install Python dependencies
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
         python -m pip install copier
+    
     - name: Generate package
       run: |
         copier --vcs-ref HEAD --defaults ${{ matrix.copier_config.extra_flags }} copy ./ ../test/${{ matrix.copier_config.foldername }}
         cd ../test/${{ matrix.copier_config.foldername }}
         cat .copier-answers.yml
+    
     - name: Build package
       run: |
         cd ../test/${{ matrix.copier_config.foldername }}
         pip install .
         pip install .[dev]
+    
     - name: pylint checks
+      if: ${{ contains (matrix.copier_config.name, 'Base') }}
       run: |
         cd ../test/${{ matrix.copier_config.foldername }}
         python -m pylint --recursive=y ./src/ --rcfile=./src/.pylintrc
+   
     - name: black checks
+      if: ${{ contains(matrix.copier_config.extra_flags, 'preferred_linter=black') }}
       uses: psf/black@stable
       with:
         src: "../test/${{ matrix.copier_config.foldername }}/src"
+   
     - name: Install notebook requirements
-      if: ${{ true }}
+      if: ${{ !contains(matrix.copier_config.extra_flags, 'include_notebooks=no') }}
       run: |
         sudo apt-get install pandoc
         pip install -r ../test/${{ matrix.copier_config.foldername }}/docs/requirements.txt
         cat ../test/${{ matrix.copier_config.foldername }}/docs/requirements.txt
+    
     - name: Build docs
       run: |
         cd ../test/${{ matrix.copier_config.foldername }}
         sphinx-build -T -E -b html -d docs/build/doctrees ./docs docs/build/html
+    
     - name: Tests
+      if: ${{ !contains(matrix.copier_config.extra_flags, 'create_example_module=no') }}
       run: |
         cd ../test/${{ matrix.copier_config.foldername }}
         python -m pytest tests --cov=${{ matrix.copier_config.module_name }} --cov-report=xml


### PR DESCRIPTION
### Considerations for this PR:
#### No flags are specified in default run.
- The ci.yml had no `extra_flags` specified in the default case (makes sense)
- This lead to weird conditioning, such as pylint's step needing `if: ${{ contains (matrix.copier_config.name, 'Base') }}` to check that we wanted pylint in this run.
- The alternative would have been checking that we did not have `linter=black` set in our extra flags
- Neither is great (first breaks when we rename the default run; second breaks when we add or change alternative linters)
- Maybe it would be better to always specify extra flags, even in the default run?
    - _(How do we make sure they stay default?)_
- Maybe we can access the copier answers file once we generate the package?
    - _(Can we do this elegantly?)_

### Considerations for the CI in general:
_(will be copied over to the issue once this PR is closed)_
#### This just tests the first available non-default option.
- Some questions have more than two options, like `mypy_type_checking` including `none`, `basic`, and `strict`. 
- Do we want to exhaustively check each option? 
- Do we care which combinations are present (eg, `pylint + BSD license + lfs disabled` but also `pylint + no license + lfs enabled`), or is it sufficient to make sure we check each option at least once?

#### This only lets us run the existing CI checks with different options.
- This does not technically do any checks that the options have worked as intended, beyond implicit assumptions like _"we can only run the pytests on a module that has, in fact, been made"_ or _"we can only run a pylint check if the options we picked lead us to actually install it."_ 
- So, this corrects our CI and lays the necessary foundation for further work, but it does not provide the thorough checks described in #77.