### PR TITLE
Moved the Copier mypy question to the "custom" install decision path.

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -70,6 +70,7 @@ mypy_type_checking:
         No type checking: none
         Add basic type checking for code that has type hints: basic
         Add strict type checking to enforce that type hints are used: strict
+    when: "{{ custom_install }}"
 
 create_example_module:
     help: Do you want to create some example module code?


### PR DESCRIPTION
This PR just move the MyPy question into the custom question set when hydrating a new project. Prior to this, the user was asked about MyPy even in "simple" installs. Since the package may be unfamiliar to the broader community and a reasonable default value is already provided I think it makes sense to include this as a custom question. 