### PR TITLE
Added jinja logic to exclude author_email if it is not provided.

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -3,7 +3,7 @@ name = "{{project_name}}"
 license = {file = "LICENSE"}
 readme = "README.md"
 authors = [
-    { name = "{{author_name}}", email = "{{author_email}}" }
+    { name = "{{author_name}}"{% if author_email %}, email = "{{author_email}}"{% endif %} }
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
The build/install will fail if there is an author with an empty email. Thus if email is not provided, we'll exclude the email field entirely. Note that there is no such restriction on name being empty. 