### PR TITLE
Update template workflows so that they all run with python 3.8-3.10.

### DIFF
--- a/python-project-template/.github/workflows/publish-to-pypi.yml
+++ b/python-project-template/.github/workflows/publish-to-pypi.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/python-project-template/.github/workflows/{% if mypy_type_checking != 'none' %}type-checking.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if mypy_type_checking != 'none' %}type-checking.yml{% endif %}.jinja
@@ -12,12 +12,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
@@ -12,12 +12,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
Some of our built in workflows were running only on python 3.10. Others were running over 3.8-3.10. This PR updates all the workflows to run over 3.8-3.10 for consistency. 