### PR TITLE
Adopting concise CLI switches for nbconvert pre-commit hook.

### DIFF
--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -20,7 +20,7 @@ repos:
         files: \.ipynb$
         stages: [commit]
         language: system
-        entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
+        entry: jupyter nbconvert --clear-output
 
     # Run unit tests, verify that they pass. Note that coverage is run against
     # the ./src directory here because that is what will be committed. In the 


### PR DESCRIPTION
This PR changes the pre-commit hook that clears output from notebooks to use the cleaner switch `--clear-output` that was introduced in this PR: https://github.com/jupyter/nbconvert/pull/619