### PR TITLE
Added more exclude patterns when not building notebooks.

### DIFF
--- a/python-project-template/docs/Makefile.jinja
+++ b/python-project-template/docs/Makefile.jinja
@@ -5,7 +5,7 @@
 # from the environment for the first two.
 SPHINXOPTS    ?= -T -E -d _build/doctrees -D language=en
 {%- if include_notebooks %}
-EXCLUDENB     ?= -D exclude_patterns="notebooks/*"
+EXCLUDENB     ?= -D exclude_patterns="notebooks/*","_build","**.ipynb_checkpoints"
 {%- endif %}
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .


### PR DESCRIPTION
This PR adds two more exclusion patterns to the CLI switch used when we don't want to build notebooks. 

The CLI switch unexpectedly overrides (instead of augments) the exclude patterns defined in `./docs/conf.py`, so I've added the patterns in the conf.py file to the make file switch.