### PR TITLE
Add comment about keeping dependencies in sync manually

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -41,8 +41,11 @@ dev = [
     "mypy", # Used for static type checking of files
 {%- endif %}
 {%- if include_notebooks %}
+    # if you add dependencies here while experimenting in a notebook and you
+    # want that notebook to render in your documentation, please add the
+    # dependencies to ./docs/requirements.txt as well.
     "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
-    "nbsphinx", # Used to itegrate Python notebooks into Sphinx documentation
+    "nbsphinx", # Used to integrate Python notebooks into Sphinx documentation
     "ipython", # Also used in building notebooks into Sphinx
     "matplotlib", # Used in sample notebook intro_notebook.ipynb
     "numpy", # Used in sample notebook intro_notebook.ipynb


### PR DESCRIPTION
Added a comment about keeping dependencies in sync between pyproject.toml and docs/requirements.txt specifically related to the case when the user wants to render jupyter notebooks in the documentation. 