### PR TITLE
Import functions explicitly, avoiding wildcard

### DIFF
--- a/python-project-template/src/{{module_name}}/__init__.py.jinja
+++ b/python-project-template/src/{{module_name}}/__init__.py.jinja
@@ -1,3 +1,5 @@
 {%- if create_example_module -%}
-from .example_module import *
+from .example_module import greetings, meaning
+
+__all__ = ["greetings", "meaning"]
 {% endif -%}


### PR DESCRIPTION
## Overview

This PR changes the example `__init__.py` to be more explicit in the functions import from `example_module`. This fixes #170 as wildcard import is not best practice in Python.