### PR TITLE
Updating pre-commit command for sphinx builds.

### DIFF
--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -150,11 +150,11 @@ repos:
                   # Note: -M requires next 3 args to be builder, source, output
             "html", # Specify builder
             "./docs", # Source directory of documents
-            "./docs/build/html", # Output directory for rendered documents
+            "./_readthedocs", # Output directory for rendered documents
             "-T", # Show full trace back on exception
             "-E", # Don't use saved env; always read all files
             "-d", # Flag for cached environment and doctrees
-            "./docs/build/doctrees", # Directory
+            "./docs/_build/doctrees", # Directory
             "-D", # Flag to override settings in conf.py
             "exclude_patterns=notebooks/*", # Exclude our notebooks from pre-commit
           ]
@@ -175,8 +175,8 @@ repos:
             "-b", # Flag to select which builder to use
             "html", # Use the HTML builder
             "-d", # Flag for cached environment and doctrees
-            "docs/build/doctrees", # directory
+            "./docs/_build/doctrees", # directory
             "./docs", # Source directory of documents
-            "docs/build/html", # Output directory for rendered documents.
+            "./_readthedocs", # Output directory for rendered documents.
           ]
 {%- endif %}


### PR DESCRIPTION
The pre-commit hook and the Make file for building documentation were pushing output files to different locations. Specifically, the pre-commit hook was sending output files to `./docs/build/...` while the make file was using `./docs/_build` and `./_readthedocs`. 

The changes in this PR will bring the pre-commit hooks (w/ and w/o notebook rendering) into alignment with the sphinx Make file.

I've tested this locally by repeatedly running the following commands:
`make html`
and
`pre-commit run --all-files sphinx-build` 
over two different hydrated projects. 

The first was created with notebook rendering enabled, and the second was created without notebook rendering. 