### PR TITLE
Add return type hint to sample tests

### DIFF
--- a/python-project-template/tests/{{module_name}}/{% if create_example_module %}test_example_module.py{% endif %}.jinja
+++ b/python-project-template/tests/{{module_name}}/{% if create_example_module %}test_example_module.py{% endif %}.jinja
@@ -1,13 +1,13 @@
 from {{module_name}} import example_module
 
 
-def test_greetings():
+def test_greetings() -> None:
     """Verify the output of the `greetings` function"""
     output = example_module.greetings()
     assert output == "Hello from LINCC-Frameworks!"
 
 
-def test_meaning():
+def test_meaning() -> None:
     """Verify the output of the `meaning` function"""
     output = example_module.meaning()
     assert output == 42


### PR DESCRIPTION
When instantiating the template with strict type checking, the generated tests fail on the `mypy` check due to missing type annotations.
```
mypy (python files in src/ and tests/)...................................Failed
- hook id: mypy
- exit code: 1

tests/uwloc_data/test_example_module.py:4: error: Function is missing a return type annotation  [no-untyped-def]
tests/uwloc_data/test_example_module.py:4: note: Use "-> None" if function does not return a value
tests/uwloc_data/test_example_module.py:10: error: Function is missing a return type annotation  [no-untyped-def]
tests/uwloc_data/test_example_module.py:10: note: Use "-> None" if function does not return a value
```

This is the straightforward fix, but let me know if we should do this conditional on `if mypy_type_checking == ...`. 