### PR TITLE
changed to pyproject.toml to install py.typed when using mypy

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -61,10 +61,13 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/{{module_name}}/_version.py"
-
 {%- if preferred_linter == 'black' %}
 
 [tool.black]
 line-length = 110
+{%- endif %}
+{%- if mypy_type_checking != 'none' %}
 
-{% endif -%}
+[tool.setuptools.package-data]
+{{module_name}} = ["py.typed"]
+{%- endif %}


### PR DESCRIPTION
So "pip install ." will create the py.typed file in the installation.

