### PR TITLE
Add configuration to pyproject.toml so that isort works with black

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -66,6 +66,7 @@ write_to = "src/{{package_name}}/_version.py"
 [tool.black]
 line-length = 110
 
+
 {%- if use_isort %}
 [tool.isort]
 profile = "black"

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -65,7 +65,6 @@ write_to = "src/{{package_name}}/_version.py"
 
 [tool.black]
 line-length = 110
-
 {% if use_isort %}
 [tool.isort]
 profile = "black"

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -65,6 +65,12 @@ write_to = "src/{{package_name}}/_version.py"
 
 [tool.black]
 line-length = 110
+
+{%- if use_isort %}
+[tool.isort]
+profile = "black"
+{%- endif %}
+
 {%- endif %}
 {%- if mypy_type_checking != 'none' %}
 

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -66,8 +66,7 @@ write_to = "src/{{package_name}}/_version.py"
 [tool.black]
 line-length = 110
 
-
-{%- if use_isort %}
+{% if use_isort %}
 [tool.isort]
 profile = "black"
 {%- endif %}


### PR DESCRIPTION
There are times when isort and black will conflict with each other when formatting imports. This PR will configure isort to behave in a way that black prefers. 

I tested this by locally creating 4 hydrated projects:
- With black and isort
- With black no isort
- Without black with isort
- Without black without isort