### PR TITLE
renamed package references

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 sphinx==6.1.3
-sphinx_rtd_theme==1.2.0
+sphinx-rtd-theme==1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = ["version"]
 dependencies = [
     "setuptools_scm",
     "sphinx==6.1.3", # Used to automatically generate documentation
-    "sphinx_rtd_theme==1.2.0", # Used to render documentation
+    "sphinx-rtd-theme==1.2.0", # Used to render documentation
 ]
 
 [build-system]

--- a/python-project-template/docs/requirements.txt.jinja
+++ b/python-project-template/docs/requirements.txt.jinja
@@ -1,5 +1,5 @@
 sphinx==6.1.3
-sphinx_rtd_theme==1.2.0
+sphinx-rtd-theme==1.2.0
 sphinx-autoapi==2.0.1
 {%- if include_notebooks %}
 nbsphinx

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -30,7 +30,7 @@ dev = [
     "pytest-cov", # Used to report total code coverage
     "pre-commit", # Used to run checks before finalizing a git commit
     "sphinx==6.1.3", # Used to automatically generate documentation
-    "sphinx_rtd_theme==1.2.0", # Used to render documentation
+    "sphinx-rtd-theme==1.2.0", # Used to render documentation
     "sphinx-autoapi==2.0.1", # Used to automatically generate api documentation
 {%- if preferred_linter == 'pylint' %}
     "pylint", # Used for static linting of files


### PR DESCRIPTION
 of sphinx_rtd_theme to sphinx-rtd-theme since that is what is in pypi.org.
Making the confusing situation a little less weird since pypi lists the package only as sphinx-rtd-theme
and conda manages to install both names if you ask for either.
The docs intimate the choice I made. See https://pypi.org/project/sphinx-rtd-theme/
and https://github.com/readthedocs/sphinx_rtd_theme/issues/1363

Might just save some downstream headaches (although I doubt the situation will ever change).
