### PR TITLE
changed versions to >= for sphinx and sphinx-rtd-theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==6.1.3
-sphinx-rtd-theme==1.2.0
+sphinx>=6.1.3
+sphinx-rtd-theme>=1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dynamic = ["version"]
 
 dependencies = [
     "setuptools_scm",
-    "sphinx==6.1.3", # Used to automatically generate documentation
-    "sphinx-rtd-theme==1.2.0", # Used to render documentation
+    "sphinx>=6.1.3", # Used to automatically generate documentation
+    "sphinx-rtd-theme>=1.2.0", # Used to render documentation
 ]
 
 [build-system]


### PR DESCRIPTION
No known need to pin them to particular version (unless tests fail!)
