### PR TITLE
pin copier below 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        python -m pip install copier mypy
+        python -m pip install 'copier<8.0' mypy
     
     - name: Generate package
       run: |


### PR DESCRIPTION
attempt to avoid problem with missing --vcs-ref (patch)
