### PR TITLE
List dependencies. Add help text.

### DIFF
--- a/docs/practices/ci_testing.rst
+++ b/docs/practices/ci_testing.rst
@@ -29,3 +29,24 @@ template that uses GitHub as a repository will automatically have CI enabled.
 The ``.github/workflows/smoke-test.yml`` file configures the scheduled smoke test.
 It uses standard cron notation to start the job at 0645 every day. This time was 
 selected to be a little far away from an hour break, when most tests would likely run.
+
+Version culprit
+-------------------------------------------------------------------------------
+
+If you want some help tracking down your failures, looking for upstream package
+updates is a good place to start. The smoke test has a "List dependencies" stage
+that will print out all packages installed through pip and their installed versions.
+
+1. Find the last successful run of the smoke test
+   1. github repo -> Actions
+   2. "Unit test smoke test"
+   3. Scroll until you find a green check
+   4. Pick a python versioned build
+   5. Expand "List dependencies"
+2. Find a failed run.
+   1. From the "Unit test smoke test" page, find the first red check
+   2. Pick a python versioned build
+   3. Expand "List dependencies"
+3. Diff those lists
+   1. e.g. ``diff pass.txt fail.txt``
+   2. Or use an online diff tool like https://www.diffchecker.com/

--- a/docs/practices/ci_testing.rst
+++ b/docs/practices/ci_testing.rst
@@ -42,10 +42,12 @@ that will print out all packages installed through pip and their installed versi
    2. "Unit test smoke test"
    3. Scroll until you find a green check
    4. Pick a python versioned build
+   5. Expand "List dependencies"
    6. Cut'n'paste the list to a file, e.g. "pass.txt"
 2. Find a failed run.
    1. From the "Unit test smoke test" page, find the first red check
    2. Pick a python versioned build
+   3. Expand "List dependencies"
    4. Cut'n'paste the list to a file, e.g. "fail.txt"
 3. Diff those lists
    1. e.g. ``diff pass.txt fail.txt``

--- a/docs/practices/ci_testing.rst
+++ b/docs/practices/ci_testing.rst
@@ -42,11 +42,11 @@ that will print out all packages installed through pip and their installed versi
    2. "Unit test smoke test"
    3. Scroll until you find a green check
    4. Pick a python versioned build
-   5. Expand "List dependencies"
+   6. Cut'n'paste the list to a file, e.g. "pass.txt"
 2. Find a failed run.
    1. From the "Unit test smoke test" page, find the first red check
    2. Pick a python versioned build
-   3. Expand "List dependencies"
+   4. Cut'n'paste the list to a file, e.g. "fail.txt"
 3. Diff those lists
    1. e.g. ``diff pass.txt fail.txt``
    2. Or use an online diff tool like https://www.diffchecker.com/

--- a/python-project-template/.github/workflows/smoke-test.yml
+++ b/python-project-template/.github/workflows/smoke-test.yml
@@ -1,5 +1,7 @@
 # This workflow will run daily at 06:45.
 # It will install Python dependencies and run tests with a variety of Python versions.
+# See documentation for help debugging smoke test issues:
+#    https://lincc-ppt.readthedocs.io/en/latest/practices/ci_testing.html#version-culprit
 
 name: Unit test smoke test
 
@@ -28,6 +30,9 @@ jobs:
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: List dependencies
+      run: |
+        pip list
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests


### PR DESCRIPTION
This adds a new step to the smoke test to list ALL the dependencies and their versions. This should be easier to diff between successful and failing runs to determine which dependency has introduced a regression.