### PR TITLE
Match RTD build steps

### DIFF
--- a/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
@@ -24,9 +24,8 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
+        if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
         pip install .
-        pip install .[dev]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 {%- if include_notebooks %}
     - name: Install notebook requirements
       run: |


### PR DESCRIPTION
## Change Description

Reorder and match dependency installation steps to match RTD steps. Closes #171 .

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests