### PR TITLE
Updating the revision of pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         sudo apt-get update
         python -m pip install --upgrade pip
         python -m pip install copier mypy
+        python -m pip install -U 'pydantic<2'
     
     - name: Generate package
       run: |

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -4,7 +4,7 @@ repos:
     # This hook should always pass. It will print a message if the local version 
     # is out of date.
   - repo: https://github.com/lincc-frameworks/pre-commit-hooks
-    rev: v0.1
+    rev: v0.1.1
     hooks:
       - id: check-lincc-frameworks-template-version
         name: Check template version


### PR DESCRIPTION
The pre-commit hook that checks the version of the template being used was pinned to a prior version. This commit updates the revision so that it uses the newest hook (that works with python 3.8)

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests