### PR TITLE
Adding .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,6 @@ dmypy.json
 
 # vscode
 .vscode/
+
+# Mac OS
 .DS_Store

--- a/python-project-template/.gitignore
+++ b/python-project-template/.gitignore
@@ -138,3 +138,6 @@ dask-worker-space/
 
 # tmp directory
 tmp/
+
+# Mac OS
+.DS_Store


### PR DESCRIPTION
## Change Description
Have ended up adding this to more than one PPT-made-project I've worked with, so I'm adding it here as well

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests