### PR TITLE
ci fix for namespace packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         git config --global user.email "tstname@example.com"
         git config --global user.name "Test Name"       
         git init --initial-branch=main
-        git add README.md .copier-answers.yml
+        git add src
         git commit -m initial
         pip install .
         pip install .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,11 @@ jobs:
     - name: Build package
       run: |
         cd ../test/${{ matrix.copier_config.foldername }}
+        git config --global user.email "tstname@example.com"
+        git config --global user.name "Test Name"       
         git init --initial-branch=main
+        git add README.md .copier-answers.yml
+        git commit -m initial
         pip install .
         pip install .[dev]
     


### PR DESCRIPTION
## Change Description

namespace packages seem to require an actual commit to correctly installj.
Without the commit the namespace package does not include the subpackage
resulting in import failures. If your project is "acme-widget" namespace is "acme" and your subpackage is
"widget" then
import acme.widget
will fail because site-packages will have "acme-widget" and "acme" but "acme" will not have "acme/widget".

Having an actual commit fixes this. I do not understand why it matters.

## Checklist

- [] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests