### PR TITLE
Update directory names of the ASV outputs

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -77,7 +77,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add results/
+          git add _results/ -f
           git pull
           git commit -m "Upload new benchmarks"
           git push origin main
@@ -90,4 +90,4 @@ jobs:
       - name: Deploy to Github pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: {% raw %}${{ env.WORKING_DIR }}{% endraw %}/html
+          folder: {% raw %}${{ env.WORKING_DIR }}{% endraw %}/_html


### PR DESCRIPTION
Fix directory names of the outputs on the **asv-main** workflow.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests