### PR TITLE
Issue/251/default line length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "_version.py"
+
+[tool.black]
+line-length = 110
+target-version = ["py38"]
+
+[tool.isort]
+profile = "black"
+line_length = 110

--- a/python-project-template/src/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
+++ b/python-project-template/src/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
@@ -329,7 +329,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=110
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/python-project-template/tests/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
+++ b/python-project-template/tests/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
@@ -329,7 +329,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=110
 
 # Maximum number of lines in a module.
 max-module-lines=1000


### PR DESCRIPTION
## Change Description
Added the default line length 110 to pyproject.toml and updated the default line length to 110 for the .pylintrc

Issue #251 
