### PR TITLE
Specify asv version

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -66,7 +66,7 @@ jobs:
         run: |
           sudo apt-get update
           python -m pip install --upgrade pip
-          pip install asv virtualenv tabulate
+          pip install asv==0.5.1 virtualenv tabulate
 
       - name: Configure git
         run: |

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo apt-get update
           python -m pip install --upgrade pip
-          pip install asv virtualenv
+          pip install asv==0.5.1 virtualenv
 
       - name: Create ASV machine config file
         run: asv machine --machine gh-runner --yes

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo apt-get update
           python -m pip install --upgrade pip
-          pip install asv virtualenv tabulate lf-asv-formatter
+          pip install asv==0.5.1 virtualenv tabulate lf-asv-formatter
 
       - name: Get current job logs URL
         uses: Tiryoh/gha-jobid-action@v0


### PR DESCRIPTION
A new _asv_ release (0.6.0) introduced breaking changes that are impacting the benchmarking workflows. This PR sets the previous version of asv (0.5.1) as the one to be used, while we do not decide to upgrade it. Upgrading asv will require an update of the _lf_asv_formatter_, as the output of asv commands seem to have changed significantly.

Closes #265. 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests