### PR TITLE
Remove pydantic requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
         sudo apt-get update
         python -m pip install --upgrade pip
         python -m pip install copier mypy
-        python -m pip install -U 'pydantic<2'
     
     - name: Generate package
       run: |


### PR DESCRIPTION
## Change Description

Removes pydantic version requirement - was for an earlier version of copier.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change includes integration testing, or is small enough to be covered by existing tests