### PR TITLE
Pin asv version in pyproject.toml

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -54,7 +54,7 @@ dev = [
     "numpy", # Used in sample notebook intro_notebook.ipynb
 {%- endif %}
 {%- if include_benchmarks %}
-    "asv", # Used to compute performance benchmarks
+    "asv==0.5.1", # Used to compute performance benchmarks
 {%- endif %}
 ]
 


### PR DESCRIPTION
Pins asv version in _pyproject.toml_. 

Closes #272.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests