### PR TITLE
Pre-commit-ci workflow

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,8 +27,9 @@ We think it's really neat, and we hope you do to!
    :caption: Best Practices
 
    practices/overview
-   practices/ci_testing
    practices/ci_benchmarking
+   practices/ci_precommit
+   practices/ci_testing
    practices/code_coverage
    practices/git-lfs
    practices/linting

--- a/docs/practices/ci_precommit.rst
+++ b/docs/practices/ci_precommit.rst
@@ -1,0 +1,39 @@
+Continuous Integration Pre-Commit
+===============================================================================
+
+What is it? Why do it?
+-------------------------------------------------------------------------------
+
+Continuous integration Pre-Commit is the practice of running a set of hooks 
+that enforce code styling consistency whenever new changes are proposed.
+
+`pre-commit <https://pre-commit.com>`_ hooks should be setup locally, so one can
+apply the required fixes before committing. That is an assumption not all
+developers comply with, and therefore, it's useful to have a GitHub workflow 
+to help enforcing code style and keep it consistent during development.
+
+Using `pre-commit.ci lite <https://pre-commit.ci/lite>`_, we incorporate a bot
+into our project that performs as many automatic fixes as possible and reports
+any linting issues that it could not resolve but should be fixed.
+
+For each pull request, our ``pre-commit.ci`` workflow will:
+
+* Clear outputs from Jupyter notebooks
+* Format code using ``black`` (python and notebook files)
+* Sort imports using ``isort`` (python and notebook files)
+* Check compliance with ``pylint`` rules (python files under ``src`` and ``test``)
+
+.. note::
+   * Only a small subset of hooks declared in the ``.pre-commit-config.yaml`` file
+     are relevant for the CI pipeline. For more information on the list of available
+     hooks visit :doc:`Pre-Commit <../practices/precommit>`.
+
+How to activate
+-------------------------------------------------------------------------------
+
+The template will automatically generate the ``pre-commit-ci.yml`` workflow file
+if you have chosen a linter when setting up the project with ``copier``.
+
+To finish the configuration of this feature and activate the automatic fixes on the
+pull requests, you need to install the pre-commit application for your relevant 
+GitHub repository (`link <https://github.com/apps/pre-commit-ci-lite/installations/new>`_).

--- a/docs/practices/ci_precommit.rst
+++ b/docs/practices/ci_precommit.rst
@@ -19,21 +19,21 @@ any linting issues that it could not resolve but should be fixed.
 For each pull request, our ``pre-commit.ci`` workflow will:
 
 * Clear outputs from Jupyter notebooks
-* Format code using ``black`` (python and notebook files)
-* Sort imports using ``isort`` (python and notebook files)
-* Check compliance with ``pylint`` rules (python files under ``src`` and ``test``)
+* Sort imports using ``isort`` (python files)
+* According to the preferred linter selected:
+   * Format code using ``black`` (python and notebook files)
+   * Check compliance with ``pylint`` rules (python files)
 
 .. note::
-   * Only a small subset of hooks declared in the ``.pre-commit-config.yaml`` file
-     are relevant for the CI pipeline. For more information on the list of available
-     hooks visit :doc:`Pre-Commit <../practices/precommit>`.
+  * Only a small subset of hooks declared in the ``.pre-commit-config.yaml`` file
+    are relevant for the CI pipeline. For more information on the list of available
+    hooks visit :doc:`Pre-Commit <../practices/precommit>`.
 
 How to activate
 -------------------------------------------------------------------------------
 
 The template will automatically generate the ``pre-commit-ci.yml`` workflow file
-if you have chosen a linter when setting up the project with ``copier``.
-
-To finish the configuration of this feature and activate the automatic fixes on the
-pull requests, you need to install the pre-commit application for your relevant 
-GitHub repository (`link <https://github.com/apps/pre-commit-ci-lite/installations/new>`_).
+if you have chosen a linter when setting up the project with ``copier``. To finish 
+the configuration of this feature and activate the automatic fixes on pull requests, 
+you need to `install <https://github.com/apps/pre-commit-ci-lite/installations/new>`_
+the pre-commit application for your relevant GitHub repository.

--- a/docs/practices/ci_precommit.rst
+++ b/docs/practices/ci_precommit.rst
@@ -10,7 +10,7 @@ that enforce code styling consistency whenever new changes are proposed.
 `pre-commit <https://pre-commit.com>`_ hooks should be setup locally, so one can
 apply the required fixes before committing. That is an assumption not all
 developers comply with, and therefore, it's useful to have a GitHub workflow 
-to help enforcing code style and keep it consistent during development.
+to help enforcing code style and keeping it consistent during development.
 
 Using `pre-commit.ci lite <https://pre-commit.ci/lite>`_, we incorporate a bot
 into our project that performs as many automatic fixes as possible and reports
@@ -19,14 +19,14 @@ any linting issues that it could not resolve but should be fixed.
 For each pull request, our ``pre-commit.ci`` workflow will:
 
 * Clear outputs from Jupyter notebooks
-* Sort imports using ``isort`` (python files)
+* Sort imports using ``isort``
 * According to the preferred linter selected:
-   * Format code using ``black`` (python and notebook files)
-   * Check compliance with ``pylint`` rules (python files)
+   * Format code using ``black`` (including notebooks)
+   * Check compliance with ``pylint`` rules
 
 .. note::
   * Only a small subset of hooks declared in the ``.pre-commit-config.yaml`` file
-    are relevant for the CI pipeline. For more information on the list of available
+    is relevant for the CI pipeline. For more information on the list of available
     hooks visit :doc:`Pre-Commit <../practices/precommit>`.
 
 How to activate

--- a/docs/practices/overview.rst
+++ b/docs/practices/overview.rst
@@ -10,8 +10,9 @@ additional pointers you might want as you work within these practices.
 Practices
 -------------------------------------------------------------------------------
 
-* :doc:`ci_testing`
 * :doc:`ci_benchmarking`
+* :doc:`ci_precommit`
+* :doc:`ci_testing`
 * :doc:`code_coverage`
 * :doc:`linting`
 * :doc:`pipx`

--- a/docs/practices/precommit.rst
+++ b/docs/practices/precommit.rst
@@ -43,19 +43,18 @@ of these that are not useful for your project.
      - Prevents committing very large files. The default file size threshold is 500kb and is configurable.
    * - Validate pyproject.toml
      - Verify pyproject.toml adheres to the required schema to avoid changes that would break the build.
-   * - isort (python files in src/ and tests/)
-     - Runs isort to sort and organize your python package imports. *(Optionally installed when project is created.)*
+   * - isort
+     - Runs isort to sort and organize your python package imports on .py and .pyi files. One can add more file extensions by editing this hook on ``.pre-commit-config.yaml`` directly. *(Optionally installed when project is created.)*
    * - pylint (python files in src/)
      - Runs pylint to enforce a particular code style on python files in the src/ directory. *(Optionally installed when project is created.)*
-   * - pylint (python files in tests/)
-     - Same as above, but for the tests/ directory. *(Optionally installed when project is created.)*
+   * - pylint (python files in tests/ and benchmarks/)
+     - Same as above, but for the tests/ and benchmarks/ directory. *(Optionally installed when project is created.)*
    * - black
-     - Runs black to enforce a particular code style on python files in the src/ and tests/ directories. *(Optionally installed when project is created.)*
+     - Runs black to enforce a particular code style on .py, .pyi and .ipynb files. One can add more file extensions by editing this hook on ``.pre-commit-config.yaml`` directly. *(Optionally installed when project is created.)*
    * - mypy
      - Runs static type checking on python files in the src/ and tests/ directories. *(Optionally installed when project is created.)*
    * - Build documentation with Sphinx
      - Ensures that automatically generated documentation and, optionally, jupyter notebooks can be built successfully.
-
 
 Many other pre-commit hooks exist, a partial list can be found in the pre-commit 
 `documentation <https://pre-commit.com/hooks.html>`_.

--- a/python-project-template/.github/workflows/pre-commit-ci.yml
+++ b/python-project-template/.github/workflows/pre-commit-ci.yml
@@ -1,0 +1,35 @@
+# This workflow runs pre-commit hooks on pull requests to enforce coding style.
+# To ensure correct configuration, please refer to:
+#   TODO: UPDATE LINK HERE
+# https://lincc-ppt.readthedocs.io/en/latest/practices/ci_pre-commit.html#version-culprit
+
+name: Run pre-commit hooks
+
+on:
+  pull_request:
+
+jobs:
+  pre-commit-ci:
+    runs-on: ubuntu-latest
+    env: 
+      SKIP: "check-lincc-frameworks-template-version,pytest-check,no-commit-to-branch,validate-pyproject,check-added-large-files,sphinx-build"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        python -m pip install --upgrade pip
+        pip install .
+        pip install .[dev]
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
+    - uses: pre-commit-ci/lite-action@v1.0.1
+      if: always()

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -12,6 +12,10 @@ env:
   PYTHON_VERSION: "3.10"
   WORKING_DIR: {% raw %}${{ github.workspace }}{% endraw %}/benchmarks
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
 
   setup-python:

--- a/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/python-project-template/.github/workflows/{% if mypy_type_checking != 'none' %}type-checking.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if mypy_type_checking != 'none' %}type-checking.yml{% endif %}.jinja
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
@@ -16,16 +16,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10']
-
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}pre-commit-ci.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}pre-commit-ci.yml{% endif %}.jinja
@@ -1,7 +1,6 @@
 # This workflow runs pre-commit hooks on pull requests to enforce coding style.
 # To ensure correct configuration, please refer to:
-#   TODO: UPDATE LINK HERE
-# https://lincc-ppt.readthedocs.io/en/latest/practices/ci_pre-commit.html#version-culprit
+#   https://lincc-ppt.readthedocs.io/en/latest/practices/ci_precommit.html
 
 name: Run pre-commit hooks
 

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}pre-commit-ci.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}pre-commit-ci.yml{% endif %}.jinja
@@ -29,6 +29,6 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - uses: pre-commit/action@v3.0.0
       with:
-        extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
+        extra_args: --from-ref {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %} --to-ref {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
     - uses: pre-commit-ci/lite-action@v1.0.1
       if: always()

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -57,15 +57,6 @@ repos:
         name: Validate pyproject.toml
         description: Verify that pyproject.toml adheres to the established schema.
 
-    # Run black to format code
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black-jupyter
-        name: Run black (.py and .ipnyb files)
-        description: Auto-format code with black.
-        files: ^(src|tests|docs|benchmarks)/
-        language_version: python3.10
 {% if use_isort == true %}
     # Automatically sort the imports used in .py files
   - repo: https://github.com/pycqa/isort
@@ -76,16 +67,8 @@ repos:
         description: Sort and organize imports in .py files.
         types: [python]
         files: ^(src|tests|benchmarks)/
-
-    # Automatically sort the imports used in .ipynb files
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
-    hooks:
-      - id: nbqa-isort
-        name: Run isort (jupyter notebooks)
-        files: ^docs/
-        args: ["--float-to-top"]
 {% endif %}
+
 {% if preferred_linter == 'pylint' %}
     # Analyze the src code style and report code that doesn't adhere.
   - repo: local
@@ -121,17 +104,18 @@ repos:
 {% elif preferred_linter == 'black' %}
     # Analyze the code style and report code that doesn't adhere.
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.7.0
     hooks:
-      - id: black
+      - id: black-jupyter
         types: [python]
-        files: ^(src|tests)/
+        files: ^(src|tests|docs|benchmarks)/
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
 {% endif %}
+
 {% if mypy_type_checking != 'none' %}
     # Analyze type hints and report errors.
   - repo: local
@@ -151,6 +135,7 @@ repos:
           {% endif %}
           ]
 {% endif %}
+
 {%- if include_notebooks %}
     # Make sure Sphinx can build the documentation while explicitly omitting 
     # notebooks from the docs, so users don't have to wait through the execution 

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -66,7 +66,6 @@ repos:
         description: Auto-format code with black.
         files: ^(src|tests|docs|benchmarks)/
         language_version: python3.10
-
 {% if use_isort == true %}
     # Automatically sort the imports used in .py files
   - repo: https://github.com/pycqa/isort
@@ -87,7 +86,6 @@ repos:
         files: ^docs/
         args: ["--float-to-top"]
 {% endif %}
-
 {% if preferred_linter == 'pylint' %}
     # Analyze the src code style and report code that doesn't adhere.
   - repo: local
@@ -104,6 +102,7 @@ repos:
             "-sn", # Don't display the score
             "--rcfile=src/.pylintrc",
           ]
+
     # Analyze the tests code style and report code that doesn't adhere.
   - repo: local
     hooks:
@@ -133,7 +132,6 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
 {% endif %}
-
 {% if mypy_type_checking != 'none' %}
     # Analyze type hints and report errors.
   - repo: local
@@ -153,7 +151,6 @@ repos:
           {% endif %}
           ]
 {% endif %}
-
 {%- if include_notebooks %}
     # Make sure Sphinx can build the documentation while explicitly omitting 
     # notebooks from the docs, so users don't have to wait through the execution 

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -37,7 +37,7 @@ repos:
         pass_filenames: false
         always_run: true
 
-    # prevents committing directly branches named 'main' and 'master'.
+    # Prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -49,24 +49,45 @@ repos:
         description: Prevent the user from committing very large files.
         args: ['--maxkb=500']
 
-    # verify that pyproject.toml is well formed
+    # Verify that pyproject.toml is well formed
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.12.1
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
         description: Verify that pyproject.toml adheres to the established schema.
+
+    # Run black to format code
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black-jupyter
+        name: Run black (.py and .ipnyb files)
+        description: Auto-format code with black.
+        files: ^(src|tests|docs|benchmarks)/
+        language_version: python3.10
+
 {% if use_isort == true %}
     # Automatically sort the imports used in .py files
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
-        name: isort (python files in src/ and tests/)
+        name: Run isort (python files)
         description: Sort and organize imports in .py files.
         types: [python]
-        files: ^(src|tests)/
+        files: ^(src|tests|benchmarks)/
+
+    # Automatically sort the imports used in .ipynb files
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.7.0
+    hooks:
+      - id: nbqa-isort
+        name: Run isort (jupyter notebooks)
+        files: ^docs/
+        args: ["--float-to-top"]
 {% endif %}
+
 {% if preferred_linter == 'pylint' %}
     # Analyze the src code style and report code that doesn't adhere.
   - repo: local
@@ -112,6 +133,7 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
 {% endif %}
+
 {% if mypy_type_checking != 'none' %}
     # Analyze type hints and report errors.
   - repo: local
@@ -131,6 +153,7 @@ repos:
           {% endif %}
           ]
 {% endif %}
+
 {%- if include_notebooks %}
     # Make sure Sphinx can build the documentation while explicitly omitting 
     # notebooks from the docs, so users don't have to wait through the execution 

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -63,10 +63,9 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        name: Run isort (python files)
-        description: Sort and organize imports in .py files.
-        types: [python]
-        files: ^(src|tests|benchmarks)/
+        name: Run isort
+        description: Sort and organize imports in .py and .pyi files.
+        types_or: [python, pyi]
 {% endif %}
 
 {% if preferred_linter == 'pylint' %}
@@ -107,8 +106,8 @@ repos:
     rev: 23.7.0
     hooks:
       - id: black-jupyter
-        types: [python]
-        files: ^(src|tests|docs|benchmarks)/
+        name: Format code using black
+        types_or: [python, pyi, jupyter]
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -90,11 +90,11 @@ repos:
   - repo: local
     hooks:
       - id: pylint
-        name: pylint (python files in tests/)
+        name: pylint (python files in tests/ and benchmarks/)
         entry: pylint
         language: system
         types: [python]
-        files: ^tests/
+        files: ^(tests|benchmarks)/
         args:
           [
             "-rn", # Only display messages


### PR DESCRIPTION
Implements a workflow to integrate with [pre-commit.ci lite](https://pre-commit.ci/lite). The goal is to configure a bot that performs automatic code styling fixes on open pull requests, with hooks that:

* Clear outputs from Jupyter notebooks
* Sort imports using ``isort`` (python files)
* According to the preferred linter selected:
   * Format code using ``black`` (python and notebook files)
   * Check compliance with ``pylint`` rules (python files)

Closes #135.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests