### PR TITLE
Added workflow_dispatch config to allow manual running of smoke tests from Github UI

### DIFF
--- a/python-project-template/.github/workflows/smoke-test.yml
+++ b/python-project-template/.github/workflows/smoke-test.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: 45 6 * * *
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
 

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Change Description
Added workflow_dispatch config to allow manual running of smoke tests from Github UI


## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests