### PR TITLE
Added tool.coverage.run config to omit the _version.py file

### DIFF
--- a/python-project-template/.github/workflows/smoke-test.yml
+++ b/python-project-template/.github/workflows/smoke-test.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: 45 6 * * *
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
 

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v3

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -89,4 +89,4 @@ profile = "black"
 {%- endif %}
 
 [tool.coverage.run]
-omit=["src/{{project_name}}/_version.py"]
+omit=["src/{{package_name}}/_version.py"]

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -87,3 +87,6 @@ profile = "black"
 [tool.setuptools.package-data]
 {{package_name}} = ["py.typed"]
 {%- endif %}
+
+[tool.coverage.run]
+omit=["src/{{project_name}}/_version.py"]


### PR DESCRIPTION
## Change Description
Added tool.coverage.run config to omit the _version.py file


## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests