### PR TITLE
Set 110 as default line length

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -76,9 +76,11 @@ testpaths = [
 
 [tool.black]
 line-length = 110
+target-version = ["py38"]
 {% if use_isort %}
 [tool.isort]
 profile = "black"
+line_length = 110
 {%- endif %}
 
 {%- endif %}


### PR DESCRIPTION
## Change Description
When a Python Project Template user has black as their linter, we set the default line-length to be 110 as described in issue [#251](https://github.com/lincc-frameworks/python-project-template/issues/251) 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests