### PR TITLE
Loosen default pylint restrictions

### DIFF
--- a/python-project-template/src/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
+++ b/python-project-template/src/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
@@ -183,6 +183,7 @@ good-names=i,
            k,
            ex,
            Run,
+           ra,
            _
 
 # Good variable names regexes, separated by a comma. If names match any regex,
@@ -277,19 +278,19 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=20
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=20
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=20
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
@@ -502,7 +503,7 @@ ignore-imports=yes
 ignore-signatures=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=6
 
 
 [SPELLING]

--- a/python-project-template/tests/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
+++ b/python-project-template/tests/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
@@ -183,6 +183,7 @@ good-names=i,
            k,
            ex,
            Run,
+           ra,
            _
 
 # Good variable names regexes, separated by a comma. If names match any regex,
@@ -277,19 +278,19 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=20
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=20
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=30
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
@@ -503,7 +504,7 @@ ignore-imports=yes
 ignore-signatures=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=6
 
 
 [SPELLING]


### PR DESCRIPTION
## Change Description

Changes settings mentioned in #256.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests