### PR TITLE
Updating pre-commit config file for faster development cycle.

### DIFF
--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -1,3 +1,4 @@
+fail_fast: true
 repos:
 
     # Compare the local template version to the latest remote template version
@@ -21,21 +22,6 @@ repos:
         stages: [commit]
         language: system
         entry: jupyter nbconvert --clear-output
-
-    # Run unit tests, verify that they pass. Note that coverage is run against
-    # the ./src directory here because that is what will be committed. In the 
-    # github workflow script, the coverage is run against the installed package
-    # and uploaded to Codecov by calling pytest like so:
-    # `python -m pytest --cov=<package_name> --cov-report=xml`
-  - repo: local
-    hooks:
-      - id: pytest-check
-        name: Run unit tests
-        description: Run unit tests with pytest.
-        entry: bash -c "if python -m pytest --co -qq; then python -m pytest --cov=./src --cov-report=html; fi"
-        language: system
-        pass_filenames: false
-        always_run: true
 
     # Prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -134,6 +120,21 @@ repos:
           {% endif %}
           ]
 {% endif %}
+
+    # Run unit tests, verify that they pass. Note that coverage is run against
+    # the ./src directory here because that is what will be committed. In the 
+    # github workflow script, the coverage is run against the installed package
+    # and uploaded to Codecov by calling pytest like so:
+    # `python -m pytest --cov=<package_name> --cov-report=xml`
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: Run unit tests
+        description: Run unit tests with pytest.
+        entry: bash -c "if python -m pytest --co -qq; then python -m pytest --cov=./src --cov-report=html; fi"
+        language: system
+        pass_filenames: false
+        always_run: true
 
 {%- if include_notebooks %}
     # Make sure Sphinx can build the documentation while explicitly omitting 


### PR DESCRIPTION
Moving the pytest pre-commit hook (often the longest running) to next-to-last, adding `fail_fast: true` setting.

This is a byproduct of often waiting for pre-commit pytest to run, then having the black pre-commit fail, and then having to wait for docs to build (or ctrl-c'ing). 

## Change Description
Moved pytest-check to just before doc building.
Added `fail_fast: true` to top level settings of pre-commit so that any failure will stop the pre-commit check.  


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests