### PR TITLE
Update template to use "trusted publishing" for PyPI distribution instead of API key

### DIFF
--- a/docs/practices/pypi.rst
+++ b/docs/practices/pypi.rst
@@ -21,10 +21,10 @@ to PyPI when a new release is created.
 To support this, you'll need to configure your repository.
 
 * Create and verify an account on PyPI - https://pypi.org/account/register/
-* Create a PyPI API token - https://pypi.org/help/#apitoken
-* Save the API token in your repository **as an "Action Secret"** following
-  `these instructions <https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-a-repository>`_. 
-  Save your secret API token with the name: ``PYPI_API_TOKEN``
+* Create a new PyPI trusted publisher using the appropriate instructions
+ * For previously unpublished packages: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
+ * For existing published packaged: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+* When configuring your trusted publisher, the value to use for the "Workflow name" is "publish-to-pypi.yml".
 
 
 Releasing new versions

--- a/python-project-template/.github/workflows/publish-to-pypi.yml
+++ b/python-project-template/.github/workflows/publish-to-pypi.yml
@@ -1,5 +1,5 @@
 # This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+# For more information see: https://github.com/pypa/gh-action-pypi-publish#trusted-publishing
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
@@ -19,7 +19,8 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -33,7 +34,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Updating publish to pypi workflow and associated documentation to discourage the use of API keys.

## Change Description
Modified the `publish-to-pypi.yml` file to mimic this one: https://github.com/dirac-institute/sorcha/blob/main/.github/workflows/publish-to-pypi.yml

Both are now based on the instructions provided here: https://github.com/pypa/gh-action-pypi-publish#trusted-publishing


## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests