### PR TITLE
Update existing benchmark comment on pull request

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -84,24 +84,18 @@ jobs:
         env:
           STEP_URL: "{% raw %}${{ steps.jobs.outputs.html_url }}{% endraw %}#step:8:1"
 
-      - name: Publish comment to PR
-        uses: actions/github-script@v6
+      - name: Find benchmarks comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
         with:
-          github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
+          issue-number: {% raw %}${{ github.event.pull_request.number }}{% endraw %}
+          comment-author: 'github-actions[bot]'
+          body-includes: view all benchmarks
 
-            const workingDir = process.env.WORKING_DIR;
-            try {
-              process.chdir(workingDir);
-              const comment = fs.readFileSync('output', 'utf-8');
-              const { data } = await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: comment,
-              });
-              console.log('Comment published:', data.html_url);
-            } catch (err) {
-              console.error(err);
-            }
+      - name: Create or update benchmarks comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: {% raw %}${{ steps.find-comment.outputs.comment-id }}{% endraw %}
+          issue-number: {% raw %}${{ github.event.pull_request.number }}{% endraw %}
+          body-path: {% raw %}${{ env.WORKING_DIR }}/output{% endraw %}
+          edit-mode: replace


### PR DESCRIPTION
Updates existing benchmarks comment, written by the GitHub Actions bot on the pull request, instead of creating a new one each time code is pushed to the active branch. Closes #297.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests