### PR TITLE
Update index.rst.jinja

### DIFF
--- a/python-project-template/{% if include_docs %}docs{% endif %}/index.rst.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/index.rst.jinja
@@ -36,7 +36,7 @@ Notes:
    that a set of tests will be run prior to completing a local commit. For more
    information, see the Python Project Template documentation on
    `pre-commit <https://lincc-ppt.readthedocs.io/en/latest/practices/precommit.html>`_.
-3) Install ``pandoc`` allows you to verify that automatic rendering of Jupyter notebooks
+3) Installing ``pandoc`` allows you to verify that automatic rendering of Jupyter notebooks
    into documentation for ReadTheDocs works as expected. For more information, see
    the Python Project Template documentation on
    `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/latest/practices/sphinx.html#python-notebooks>`_.


### PR DESCRIPTION
Based on comment on https://github.com/astronomy-commons/hipscat-import/pull/144

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change includes integration testing, or is small enough to be covered by existing tests