### PR TITLE
Ask user for github organization

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -24,6 +24,11 @@ package_name:
         Must use a lowercase letter followed by one or more of (a-z, 0-9, _).
         {% endif %}
 
+project_organization:
+    type: str
+    help: What github organization will your project live under? 
+    default: my_organization
+
 author_name:
     type: str
     help: What is the name of the code author? (Can be a person or organization)

--- a/docs/practices/ci_benchmarking.rst
+++ b/docs/practices/ci_benchmarking.rst
@@ -29,15 +29,8 @@ Set-up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Inside the ``benchmarks`` directory there's a file called ``asv.conf.json`` which configures 
-airspeed velocity. When first configuring the project one must manually define the following
-two URLs. The remaining fields should remain unchanged.
-
-- **project_url**: The project's homepage URL.
-- **show_commit_url**: The base URL to show a commit for the project. It is used on the
-  dashboard to enable performance data points on the plots to have a link to the respective commits. 
-  It should be similar to `<https://github.com/{{organization}}/{{project_name}}/commit/>`_.
-
-For more information about this configuration file, visit the `asv.conf.json reference <https://asv.readthedocs.io/en/stable/asv.conf.json.html>`_.
+airspeed velocity. For more information about this configuration file, visit the 
+`asv.conf.json reference <https://asv.readthedocs.io/en/stable/asv.conf.json.html>`_.
 
 .. important::
    Activate GitHub Pages for your repository, otherwise the dashboard webpage won't be accessible. 

--- a/docs/practices/pypi.rst
+++ b/docs/practices/pypi.rst
@@ -22,8 +22,10 @@ To support this, you'll need to configure your repository.
 
 * Create and verify an account on PyPI - https://pypi.org/account/register/
 * Create a new PyPI trusted publisher using the appropriate instructions
- * For previously unpublished packages: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
- * For existing published packaged: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+
+  * For previously unpublished packages: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
+  * For existing published packaged: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+   
 * When configuring your trusted publisher, the value to use for the "Workflow name" is "publish-to-pypi.yml".
 
 

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -30,31 +30,62 @@ questions:
    * - **Question**
      - **Notes**
    * - *Would you like to use simple (default tooling) or customized installation?*
-     - If a simple install is used, the template automatically selects the recommended tooling options (linter, isort, and create example module). 
+     - If a simple install is used, the template automatically selects the recommended 
+       tooling options (linter, isort, and create example module). 
    * - *What is the name of your project?*
-     - The name of your project. If you distribute your code via PyPI, this is the name that will be used. This will allow users to pip install like so: ``pip install <project_name>``. The project name must start with a lowercase letter, followed by one or more of the following (a-z, 0-9, _, -).
+     - The name of your project. If you distribute your code via PyPI, this is the name 
+       that will be used. This will allow users to pip install like so: ``pip install <project_name>``. 
+       The project name must start with a lowercase letter, followed by one or more of the 
+       following (a-z, 0-9, _, -).
    * - *What is your python package name?*
-     - The name of your top level package. Specifies the location of the source code (``src/{{package_name}}``). The package name must start with a lowercase letter, followed by one or more of the following (a-z, 0-9, _).
+     - The name of your top level package. Specifies the location of the source 
+       code (``src/{{package_name}}``). The package name must start with a lowercase letter, 
+       followed by one or more of the following (a-z, 0-9, _).
+   * - *What github organization will your project live under?*
+     - This will either be a gihub organization, or your github username, if you're working outside 
+       of an organization. This is used to construct URLs to your project, like
+       ``https://github.com/{{project_organization}}/{{project_name}}``
    * - *Your first and last name?* 
-     -  The name of code's author. This will be used in the project and documentation metadata. This name will also be included as part of the copyright license.
+     - The name of code's author. This will be used in the project and documentation metadata. 
+       This name will also be included as part of the copyright license.
    * - *Your preferred email address?*
      - The contact email for the code's author. This will be used in the project and documentation metadata.
    * - *What license would you like to use?*
-     - The license type you want to use for this project. Options are MIT and BSD. For more information on these options see `Github's license page <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository>`_.
+     - The license type you want to use for this project. Options are MIT and BSD. For more information on these options see 
+       `Github's license page <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository>`_.
    * - *What tooling would you like to use to enforce code style?*
-     - A linter is a tool to automatically format for consistency (see :doc:`Linting <../practices/linting>`). We provide options for `black <https://black.readthedocs.io/en/stable/>`_, `pylint <https://pypi.org/project/pylint/>`_, or no linter. Choosing a linter will include it as a project dependency and include it in the :doc:`pre-commit <../practices/precommit>` hooks. Defaults to ``pylint`` during simple installation. 
+     - A linter is a tool to automatically format for consistency (see :doc:`Linting <../practices/linting>`). 
+       We provide options for `black <https://black.readthedocs.io/en/stable/>`_, 
+       `pylint <https://pypi.org/project/pylint/>`_, or no linter. Choosing a linter will include it as a 
+       project dependency and include it in the :doc:`pre-commit <../practices/precommit>` hooks. 
+       Defaults to ``pylint`` during simple installation. 
    * - *Do you want to use isort to maintain a specific ordering for module imports?*
-     - `isort <https://pycqa.github.io/isort/>`_ is a tool for ordering imports in a standard order. Enabling the option will include ``isort`` as part of github's :doc:`pre-commit <../practices/precommit>`. Defaults to ``True`` during simple installation.
+     - `isort <https://pycqa.github.io/isort/>`_ is a tool for ordering imports in a standard order. 
+       Enabling the option will include ``isort`` as part of github's :doc:`pre-commit <../practices/precommit>`. 
+       Defaults to ``True`` during simple installation.
    * - *Would you like to include mypy to perform static type checking for type hints?*
-     - `mypy <https://www.mypy-lang.org>`_ performs static type checking on python code that uses `type hints <https://docs.python.org/3/library/typing.html>`_. This type checking makes sure that the correct data types are being used where type hints are defined. If basic or strict type checking is selected, a pre-commit hook and GitHub actions workflow that perform the type checking are added. Basic type checking performs type checks but ignores code or imports for which type hints are not written. Strict type checking enforces type hints are used by giving errors where no type hints are found.
+     - `mypy <https://www.mypy-lang.org>`_ performs static type checking on python code that uses 
+       `type hints <https://docs.python.org/3/library/typing.html>`_. This type checking makes sure that the 
+       correct data types are being used where type hints are defined. If basic or strict type checking is 
+       selected, a pre-commit hook and GitHub actions workflow that perform the type checking are added. 
+       Basic type checking performs type checks but ignores code or imports for which type hints are not written. 
+       Strict type checking enforces type hints are used by giving errors where no type hints are found.
    * - *Do you want to create some example module code?*
-     - If this option is selected the template will create an example module ``src/{{package_name}}/example_module.py`` and test file ``tests/{{package_name}}/test_example_module.py``. Defaults to ``True`` during simple installation.
+     - If this option is selected the template will create an example module 
+       ``src/{{package_name}}/example_module.py`` and test file 
+       ``tests/{{package_name}}/test_example_module.py``. Defaults to ``True`` during simple installation.
    * - *Do you want to include rendered notebooks in your documentation?*
-     - The requirements to host rendered notebooks on your Read the Docs (or just build them locally) will be included in your project. A sample notebook will be generated and added to your docs as an example.
+     - The requirements to host rendered notebooks on your Read the Docs (or just build them locally) will 
+       be included in your project. A sample notebook will be generated and added to your docs as an example.
    * - *Do you want to enable benchmarking?*
-     - Answering `Yes` enables benchmarking using `airspeed velocity (ASV) <https://asv.readthedocs.io/en/stable/>`_. The template will add the GitHub workflows for continuous integration and create a sample benchmarking suite under ``benchmarks/benchmarks/benchmarks.py``. Defaults to ``True`` during simple installation.
+     - Answering `Yes` enables benchmarking using 
+       `airspeed velocity (ASV) <https://asv.readthedocs.io/en/stable/>`_. The template will add the GitHub 
+       workflows for continuous integration and create a sample benchmarking suite under 
+       ``benchmarks/benchmarks/benchmarks.py``. Defaults to ``True`` during simple installation.
    * - *Do you want to add a .gitattributes with entries for git-lfs?*
-     - Support for large files for use in git. This option is primarily informational and no answer locks you in to using (or not using) git-lfs. Importantly, selecting this option does not install git-lfs for your project (see :doc:`Git_Large_File_Support <../practices/git-lfs>`).
+     - Support for large files for use in git. This option is primarily informational and no answer locks 
+       you in to using (or not using) git-lfs. Importantly, selecting this option does not install git-lfs 
+       for your project (see :doc:`Git_Large_File_Support <../practices/git-lfs>`).
 
 
 While these choices will provide the initial structure for your project, most 

--- a/python-project-template/README.md.jinja
+++ b/python-project-template/README.md.jinja
@@ -2,6 +2,16 @@
 
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
 
+[![PyPI](https://img.shields.io/pypi/v/{{project_name}}?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/{{project_name}}/)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/{{project_organization}}/{{project_name}}/smoke-test.yml)](https://github.com/{{project_organization}}/{{project_name}}/actions/workflows/smoke-test.yml)
+[![codecov](https://codecov.io/gh/{{project_organization}}/{{project_name}}/branch/main/graph/badge.svg)](https://codecov.io/gh/{{project_organization}}/{{project_name}})
+{%- if include_docs %}
+[![Read the Docs](https://img.shields.io/readthedocs/{{project_name}})](https://{{project_name}}.readthedocs.io/)
+{%- endif %}
+{%- if include_benchmarks %}
+[![benchmarks](https://img.shields.io/github/actions/workflow/status/{{project_organization}}/{{project_name}}/asv-main.yml?label=benchmarks)](https://{{project_organization}}.github.io/{{project_name}}/)
+{%- endif %}
+
 This project was automatically generated using the LINCC-Frameworks 
 [python-project-template](https://github.com/lincc-frameworks/python-project-template).
 

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -58,6 +58,10 @@ dev = [
 {%- endif %}
 ]
 
+[metadata]
+long_description = { file = "README.md" }
+url = "https://github.com/{{project_organization}}/{{project_name}}"
+
 [build-system]
 requires = [
     "setuptools>=62", # Used to build and package the Python project

--- a/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/asv.conf.json.jinja
+++ b/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/asv.conf.json.jinja
@@ -5,7 +5,7 @@
     // The name of the project being benchmarked.
     "project": "{{project_name}}",
     // The project's homepage.
-    "project_url": "Change this value according to the instructions on RTD",
+    "project_url": "https://github.com/{{project_organization}}/{{project_name}}",
     // The URL or local path of the source code repository for the
     // project being benchmarked.
     "repo": "..",
@@ -29,7 +29,7 @@
     // variable.
     "environment_type": "virtualenv",
     // the base URL to show a commit for the project.
-    "show_commit_url": "Change this value according to the instructions on RTD",
+    "show_commit_url": "https://github.com/{{project_organization}}/{{project_name}}/commit",
     // The Pythons you'd like to test against. If not provided, defaults
     // to the current version of Python used to run `asv`.
     "pythons": [


### PR DESCRIPTION
## Change Description

Closes #307 

- Adds a question to get the github organization for the project
- populates the project URL by construction 
- adds several nice badges to the README, and uses the project organization/name to fulfil the links
- fixes formatting in some documentation

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests