### PR TITLE
Updating new project section to include dependabot recommendation.

### DIFF
--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -170,7 +170,7 @@ Consider setting up branch protection rules. (`GitHub Instructions <https://docs
 This will help ensure your code is always ready to deploy by running all tests
 pass to merging into the ``main`` branch.
 
-Enable ``depndabot`` for your new repository. (`GitHub Instructions <https://docs.github.com/en/code-security/getting-started/securing-your-repository#managing-dependabot-security-updates>`_)
+Enable ``dependabot`` for your new repository. (`GitHub Instructions <https://docs.github.com/en/code-security/getting-started/securing-your-repository#managing-dependabot-security-updates>`_)
 There are several different features that ``dependabot`` offers to keep your dependencies
 up to date and your code secure. It's as easy as clicking a checkbox to get started.
 

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -159,24 +159,32 @@ Notice that when you create a PR in GitHub, a set of tests for Continuous
 Integration starts up to verify that the project can build successfully and 
 that all the unit tests pass. Neato!
 
-.. note::
-    Once your project is created and pushed to GitHub, consider setting up
-    branch protection rules. (`GitHub Instructions <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging>`_).
 
-    Pre-commit hooks can help too. Search for "UNCOMMENT" in
-    ``.pre-commit-config.yaml`` and follow the directions to setup local branch
-    protection.
+Additional configurations
+-------------------------
 
-Great, but don't stop here
--------------------------------------------------------------------------------
+Configure your GitHub repository for safety and security
+********************************************************
 
+Consider setting up branch protection rules. (`GitHub Instructions <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging>`_)
+This will help ensure your code is always ready to deploy by running all tests
+pass to merging into the ``main`` branch.
+
+Enable ``depndabot`` for your new repository. (`GitHub Instructions <https://docs.github.com/en/code-security/getting-started/securing-your-repository#managing-dependabot-security-updates>`_)
+There are several different features that ``dependabot`` offers to keep your dependencies
+up to date and your code secure. It's as easy as clicking a checkbox to get started.
+
+Add another GitHub user as an administrator on your repository (`GitHub Instructions <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository>`_).
+It's just a good idea - like having a spare set of keys for your Lamborghini.
+
+Get the most out of this template
+*********************************
 At this point, your new project is hydrated, version controlled and ready for
 you to start coding. But there's a lot more that this template has to offer!
-Take a look at the :doc:`Best Practices section <../practices/overview>` to learn about
+
+If you want to enable performance benchmarking there are some additional steps. 
+Refer to the "How to manage" section of :doc:`Continuous Integration Benchmarking <../practices/ci_benchmarking>`
+for more information.
+
+Finally, take a look at the :doc:`Best Practices section <../practices/overview>` to learn about
 built in pre-commit hooks, GitHub CI, automatic documentation, and more.
-
-.. important::
-    Benchmarking setup requires additional steps. Refer to the "How to manage" section
-    of :doc:`Continuous Integration Benchmarking <../practices/ci_benchmarking>` for more information.
-
-


### PR DESCRIPTION
## Change Description
Updating documentation to recommend the use of `dependabot`. 


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests