### PR TITLE
Patches on the asv workflows

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -86,7 +86,7 @@ jobs:
           fi
 
       - name: Run ASV for the main branch
-        run: asv run ALL --skip-existing --verbose
+        run: asv run ALL --skip-existing --verbose || true
 
       - name: Submit new results to the "benchmarks" branch
         uses: JamesIves/github-pages-deploy-action@v4

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
@@ -46,8 +46,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install asv==0.6.1 virtualenv
 
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Create ASV machine config file
         run: asv machine --machine gh-runner --yes
+
+      - name: Fetch previous results from the "benchmarks" branch
+        run: |
+          if git ls-remote --exit-code origin benchmarks > /dev/null 2>&1; then
+            git merge origin/benchmarks \
+              --allow-unrelated-histories \
+              --no-commit
+            mv ../_results .
+          fi
 
       - name: Get nightly dates under comparison
         id: nightly-dates
@@ -65,13 +79,11 @@ jobs:
         run: |
           HASH_FILE={% raw %}${{ env.NIGHTLY_HASH_FILE }}{% endraw %}
           CURRENT_HASH={% raw %}${{ github.sha }}{% endraw %}
-
           if [ -f $HASH_FILE ]; then          
             PREV_HASH=$(cat $HASH_FILE)
             asv continuous $PREV_HASH $CURRENT_HASH --verbose || true
             asv compare $PREV_HASH $CURRENT_HASH --sort ratio --verbose
           fi
-
           echo $CURRENT_HASH > $HASH_FILE
 
       - name: Update last nightly hash in cache


### PR DESCRIPTION
Applies two small fixes on the **asv-main** and **asv-nightly** workflows:

- The asv-nightly workflow is failing because we're trying to compare two commit hashes and their benchmark results are not present in the action's working directory. Previously this was not a requirement but for asv v0.0.6+ we're seeing exceptions about it ([example](https://github.com/astronomy-commons/lsdb/actions/runs/6803720656/job/18499651984)).

- According to the asv 0.6.1 [changelog](https://github.com/airspeed-velocity/asv/releases/tag/v0.6.1) both `asv run` and `asv continuous` return a non-zero exit code if any of the benchmarks fail. In the case of **asv-main**, we still want to allow the workflow to finish so that the results are stored and the dashboard is updated (hence `|| true`).

It closes [#62](https://github.com/astronomy-commons/hipscat/issues/162), issue created for hipscat but that will in fact affect all projects based on the template.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests