### PR TITLE
Remove consecutiveness action dependency

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -12,20 +12,14 @@ env:
   PYTHON_VERSION: "3.10"
   WORKING_DIR: {% raw %}${{ github.workspace }}{% endraw %}/benchmarks
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
-
-  consecutiveness:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set workflows on main to run consecutively
-        uses: mktcode/consecutive-workflow-action@eb43c6b5852dd0e33efa797a1817196d06daa4b2
-        with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
   setup-python:
     runs-on: ubuntu-latest
-    needs: consecutiveness
 
     steps:
       - name: Cache Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}


### PR DESCRIPTION
The consecutiveness action was deleted from the GitHub Marketplace. This pull request replaces its usage with a native `concurrency` job directive. Closes #318. 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests