### PR TITLE
Spruce up the conf.py files.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,11 @@ version = ".".join(release.split(".")[:2])
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 master_doc = "index"  # This assumes that sphinx-build is called from the root directory
-html_favicon = 'static/favicon.ico'
-html_show_sourcelink = (
-    False  # Remove 'view source code' from top of page (for html, not python)
-)
+html_favicon = "static/favicon.ico"
+html_show_sourcelink = False  # Remove 'view source code' from top of page (for html, not python)
 
 # Allow a custom CSS.
-html_static_path = ['static',]
+html_static_path = ["static"]
 html_css_files = ["custom.css"]
 
 # -- Options for HTML output -------------------------------------------------

--- a/python-project-template/{% if include_docs %}docs{% endif %}/conf.py.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/conf.py.jinja
@@ -6,12 +6,10 @@
 
 import os
 import sys
-
-import autoapi
 from importlib.metadata import version
 
 # Define path to the code to be documented **relative to where conf.py (this file) is kept**
-sys.path.insert(0, os.path.abspath('../src/'))
+sys.path.insert(0, os.path.abspath("../src/"))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -34,11 +32,14 @@ extensions.append("nbsphinx")
 {%- endif %}
 
 templates_path = []
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
+exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 
-master_doc = "index"  # This assumes that sphinx-build is called from the root directory
-html_show_sourcelink = False  # Remove 'view source code' from top of page (for html, not python)
-add_module_names = False # Remove namespaces from class/method signatures
+# This assumes that sphinx-build is called from the root directory
+master_doc = "index"
+# Remove 'view source code' from top of page (for html, not python)
+html_show_sourcelink = False
+# Remove namespaces from class/method signatures
+add_module_names = False
 
 autoapi_type = "python"
 autoapi_dirs = ["../src"]


### PR DESCRIPTION
## Change Description

Closes #329 

Runs black/isort on the python project itself.

Fix up the conf.py template so there are no changes on a newly-hydrated project when running black/isort.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests