### PR TITLE
Add explicit asv install command

### DIFF
--- a/docs/practices/ci_benchmarking.rst
+++ b/docs/practices/ci_benchmarking.rst
@@ -29,12 +29,13 @@ Set-up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Inside the ``benchmarks`` directory there's a file called ``asv.conf.json`` which configures 
-airspeed velocity.
+airspeed velocity. You may need to perform minor changes to this file. For example, if you need
+to install dependencies declared on a ``requirements.txt`` file, you may want to set the
+``install_command`` as follows:
 
-You may need to perform minor changes to this file. For example, if you need to install dependencies
-declared on a `requirements.txt` file, you may want to set the `install_command` as follows:
+    .. code:: bash
 
-`python -m pip install -r requirements.txt {wheel_file}`
+        python -m pip install -r requirements.txt {wheel_file}
 
 For more information about this configuration file, visit the
 `asv.conf.json reference <https://asv.readthedocs.io/en/stable/asv.conf.json.html>`_.

--- a/docs/practices/ci_benchmarking.rst
+++ b/docs/practices/ci_benchmarking.rst
@@ -29,7 +29,14 @@ Set-up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Inside the ``benchmarks`` directory there's a file called ``asv.conf.json`` which configures 
-airspeed velocity. For more information about this configuration file, visit the 
+airspeed velocity.
+
+You may need to perform minor changes to this file. For example, if you need to install dependencies
+declared on a `requirements.txt` file, you may want to set the `install_command` as follows:
+
+`python -m pip install -r requirements.txt {wheel_file}`
+
+For more information about this configuration file, visit the
 `asv.conf.json reference <https://asv.readthedocs.io/en/stable/asv.conf.json.html>`_.
 
 .. important::

--- a/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/asv.conf.json.jinja
+++ b/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/asv.conf.json.jinja
@@ -14,6 +14,9 @@
     "branches": [
         "HEAD"
     ],
+    "install_command": [
+        "python -m pip install {wheel_file}"
+    ],
     "build_command": [
         "python -m build --wheel -o {build_cache_dir} {build_dir}"
     ],


### PR DESCRIPTION
Adds the default `install_command` to the `asv.conf.json` file. It also adds an example to the documentation on how one can update this command if dependencies have been declared in a `requirements.txt`. Closes #306.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests