### PR TITLE
More commentary around the use of pipx over more familiar package managers

### DIFF
--- a/docs/practices/pipx.rst
+++ b/docs/practices/pipx.rst
@@ -46,4 +46,5 @@ An example installation of ``pipx`` might look like this.
         >> conda install -c conda-forge pipx
         >> pipx ensurepath
 
-Pro tip: Don't forget the ``pipx ensurepath`` to finalize the installation!
+.. important::
+    Don't forget to run ``pipx ensurepath`` to finalize the installation.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -33,9 +33,14 @@ It's really neat!
 .. important::
     Copier has two requirements and one recommended tool:
 
-    1. Python > 3.7 (required)
-    2. Git > 2.27 (required)
-    3. pipx (recommended - more info about pipx :doc:`here<../practices/pipx>`)
+    #. Python > 3.7 **required**
+    #. Git > 2.27 **required**
+    #. pipx *recommended*
+
+    Learn how to maintain a clean Python environment with ``pipx``
+    :doc:`here<../practices/pipx>`. We recommend using ``pipx`` to install Copier
+    for a more maintainable development environment, although some users have also
+    had success with ``conda``.
 
     You can check your requirements like so:
 


### PR DESCRIPTION
Adding to the directions to read the pipx documentation, and softening the recommendation to indicate that conda can work too.

## Change Description



## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests