### PR TITLE
Allow TODOs in comments.

### DIFF
--- a/python-project-template/src/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
+++ b/python-project-template/src/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
@@ -444,8 +444,7 @@ timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.
 
 # List of note tags to take in consideration, separated by a comma.
 notes=FIXME,
-      XXX,
-      TODO
+      XXX
 
 # Regular expression of note tags to take in consideration.
 notes-rgx=

--- a/python-project-template/tests/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
+++ b/python-project-template/tests/{% if preferred_linter == 'pylint' %}.pylintrc{% endif %}
@@ -445,8 +445,7 @@ timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.
 
 # List of note tags to take in consideration, separated by a comma.
 notes=FIXME,
-      XXX,
-      TODO
+      XXX
 
 # Regular expression of note tags to take in consideration.
 notes-rgx=


### PR DESCRIPTION
## Change Description

The `notes-rgx` field wasn't as powerful as I'd hoped, and instead I think we should just allow TODOs in comments.

Closes #341.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests