### PR TITLE
Add validation to github organization string

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -28,6 +28,10 @@ project_organization:
     type: str
     help: What github organization will your project live under? 
     default: my_organization
+    validator: >-
+        {% if not (project_organization | regex_search('^[a-z][a-z0-9\_\-]+$')) %}
+        Must use a lowercase letter followed by one or more of (a-z, 0-9, _, -).
+        {% endif %}
 
 author_name:
     type: str


### PR DESCRIPTION
## Change Description

We added this field mostly to create valid hyperlinks, and if the string is invalid, that's no good for anyone!

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests