### PR TITLE
Use the right default value for include_notebooks

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -98,7 +98,7 @@ include_docs:
 include_notebooks:
     help: Do you want to include rendered notebooks in your documentation?
     type: bool
-    default: yes
+    default: "{{ include_docs }}"
     choices:
         yes: true
         no: false

--- a/python-project-template/README.md.jinja
+++ b/python-project-template/README.md.jinja
@@ -48,7 +48,9 @@ Notes:
    that a set of tests will be run prior to completing a local commit. For more
    information, see the Python Project Template documentation on 
    [pre-commit](https://lincc-ppt.readthedocs.io/en/latest/practices/precommit.html)
+{%- if include_notebooks %}
 3) Install `pandoc` allows you to verify that automatic rendering of Jupyter notebooks
    into documentation for ReadTheDocs works as expected. For more information, see
    the Python Project Template documentation on
    [Sphinx and Python Notebooks](https://lincc-ppt.readthedocs.io/en/latest/practices/sphinx.html#python-notebooks)
+{%- endif %}


### PR DESCRIPTION
## Change Description

This is a silly thing - 

If you said "no" to `include_docs`, we didn't ask the question for `include_notebooks`. And so we don't record an answer for `include_notebooks` and the default answer from the `copier.yml` file is used in all places (which was `True`).

This sets the default according to the answer from the `include_docs`: if we're not including docs, then don't include notebooks; if we're including docs, default to also including notebooks.

Nearly all of the jinja in the rest of the template was doing the right thing, assuming you have correct values for `include_docs` and `include_notebooks`.

Closes #332

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests