### PR TITLE
Reduce footprint in intro notebook

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -53,8 +53,6 @@ dev = [
     "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
     "nbsphinx", # Used to integrate Python notebooks into Sphinx documentation
     "ipython", # Also used in building notebooks into Sphinx
-    "matplotlib", # Used in sample notebook intro_notebook.ipynb
-    "numpy", # Used in sample notebook intro_notebook.ipynb
 {%- endif %}
 {%- if include_benchmarks %}
     "asv==0.6.1", # Used to compute performance benchmarks

--- a/python-project-template/{% if include_docs %}docs{% endif %}/notebooks/{% if include_notebooks %}intro_notebook.ipynb{% endif %}
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/notebooks/{% if include_notebooks %}intro_notebook.ipynb{% endif %}
@@ -7,11 +7,13 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "# Introducing Jupyter Notebooks\n",
+    "# Introducing Jupyter Notebooks in Sphinx\n",
     "\n",
-    "_(The example used here is JamesALeedham's notebook: [intro.ipynb](https://github.com/JamesALeedham/Sphinx-Autosummary-Recursion/blob/master/docs/notebooks/intro.ipynb))_\n",
+    "This notebook showcases very basic functionality of rendering your jupyter notebooks as tutorials inside your sphinx documentation.\n",
     "\n",
-    "First, set up the environment:"
+    "As part of the LINCC Frameworks python project template, your notebooks will be executed AND rendered at document build time.\n",
+    "\n",
+    "You can read more about Sphinx, ReadTheDocs, and building notebooks in [LINCC's documentation](https://lincc-ppt.readthedocs.io/en/latest/practices/sphinx.html)"
    ]
   },
   {
@@ -21,18 +23,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib\n",
-    "import matplotlib.pyplot as pl\n",
-    "import numpy as np\n",
-    "\n",
-    "try:\n",
-    "    from IPython import get_ipython\n",
-    "    get_ipython().run_line_magic('matplotlib', 'inline')\n",
-    "except AttributeError:\n",
-    "    print('Magic function can only be used in IPython environment')\n",
-    "    matplotlib.use('Agg')\n",
-    "\n",
-    "pl.rcParams[\"figure.figsize\"] = [15, 8]"
+    "def sierpinsky(order):\n",
+    "    \"\"\"Define a method that will create a Sierpinsky triangle of given order,\n",
+    "    and will print it out.\"\"\"\n",
+    "    triangles = [\"*\"]\n",
+    "    for i in range(order):\n",
+    "        spaces = \" \" * (2**i)\n",
+    "        triangles = [spaces + triangle + spaces for triangle in triangles] + [\n",
+    "            triangle + \" \" + triangle for triangle in triangles\n",
+    "        ]\n",
+    "    print(f\"Printing order {order} triangle\")\n",
+    "    print(\"\\n\".join(triangles))"
    ]
   },
   {
@@ -43,56 +44,26 @@
     "lines_to_next_cell": 1
    },
    "source": [
-    "Then, define a function that creates a pretty graph:"
+    "Then, call our method a few times. This will happen on the fly during notebook rendering."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "funded-protection",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
-   "outputs": [],
-   "source": [
-    "def SineAndCosineWaves():\n",
-    "    # Get a large number of X values for a nice smooth curve. Using Pi as np.sin requires radians...\n",
-    "    x = np.linspace(0, 2 * np.pi, 180)\n",
-    "    # Convert radians to degrees to make for a meaningful X axis (1 radian = 57.29* degrees)\n",
-    "    xdeg = 57.29577951308232 * np.array(x)\n",
-    "    # Calculate the sine of each value of X\n",
-    "    y = np.sin(x)\n",
-    "    # Calculate the cosine of each value of X\n",
-    "    z = np.cos(x)\n",
-    "    # Plot the sine wave in blue, using degrees rather than radians on the X axis\n",
-    "    pl.plot(xdeg, y, color='blue', label='Sine wave')\n",
-    "    # Plot the cos wave in green, using degrees rather than radians on the X axis\n",
-    "    pl.plot(xdeg, z, color='green', label='Cosine wave')\n",
-    "    pl.xlabel(\"Degrees\")\n",
-    "    # More sensible X axis values\n",
-    "    pl.xticks(np.arange(0, 361, 45))\n",
-    "    pl.legend()\n",
-    "    pl.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "thorough-cutting",
-   "metadata": {
-    "cell_marker": "\"\"\""
-   },
-   "source": [
-    "Finally, call that function to display the graph:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "imported-uruguay",
    "metadata": {},
    "outputs": [],
    "source": [
-    "SineAndCosineWaves()"
+    "for order in range(3):\n",
+    "    sierpinsky(order)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sierpinsky(4)"
    ]
   }
  ],
@@ -104,7 +75,7 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  }
+    }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
@@ -6,6 +6,4 @@ nbsphinx
 ipython
 jupytext
 jupyter
-matplotlib
-numpy
 {%- endif %}


### PR DESCRIPTION
## Change Description

Closes #336 

This renders a cute little Sierpinsky triangle using list comprehension and print statements, and doesn't require any additional runtime dependencies. This lets us remove numpy and matplotlib from the starting dependencies for new projects.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests