### PR TITLE
Add page for contact information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LINCC Frameworks Python Project Template
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/lincc-frameworks/python-project-template)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/lincc-frameworks/python-project-template/ci.yml)
-![Read the Docs](https://img.shields.io/readthedocs/lincc-ppt)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/lincc-frameworks/python-project-template/ci.yml)](https://github.com/lincc-frameworks/python-project-template/ci.yml)
+[![Read the Docs](https://img.shields.io/readthedocs/lincc-ppt)](https://lincc-ppt.readthedocs.io/)
 
 This project template codifies LINCC-Framework's best practices for python code organization, testing, documentation, and automation. It is meant to help new python projects get started quickly, letting the user focus on writing code. The template takes care of the minutia of directory structures, tool configurations, and automated testing until the user is ready to take over.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,9 @@ to focus on writing code.
 
 We think it's really neat, and we hope you do to!
 
+If you find it useful, or have any questions or concerns when using the template,
+please :doc:`/source/contact`
+
 .. important:: 
    These instructions assume you are using ``copier`` version 8.0 or newer. Some
    features may not be available in older versions.
@@ -21,6 +24,7 @@ We think it's really neat, and we hope you do to!
    source/update_project
    source/existing_project
    source/contributing
+   source/contact
 
 .. toctree::
    :maxdepth: 1

--- a/docs/practices/overview.rst
+++ b/docs/practices/overview.rst
@@ -21,3 +21,8 @@ Practices
 * :doc:`sphinx`
 * :doc:`git-lfs`
 * :doc:`pytest_timeout`
+
+Still have questions?
+--------------------------------
+
+:doc:`/source/contact`

--- a/docs/source/contact.rst
+++ b/docs/source/contact.rst
@@ -1,0 +1,12 @@
+Contact us
+===============================================================================
+
+We at LINCC Frameworks pride ourselves on being a friendly bunch!
+
+If you're encountering issues, have questions about continuous integration, 
+have ideas for making our products better, or pretty much anything else, reach out!
+
+* Open an issue in our github repo for the template
+    * https://github.com/https://github.com/lincc-frameworks/python-project-template/issues/new
+* If you're on LSSTC slack, so are we! 
+  `#lincc-frameworks-qa <https://lsstc.slack.com/archives/C062LG1AK1S>`_

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -13,6 +13,8 @@ include a description - it's just polite.
 You can reach the team with bug reports, feature requests, and general inquiries
 by creating a new GitHub issue.
 
+:doc:`/source/contact`
+
 Create a branch
 -------------------------------------------------------------------------------
 
@@ -56,3 +58,5 @@ GitHub's `instructions <https://docs.github.com/en/repositories/releasing-projec
 for doing so are here. 
 Use your best judgement when incrementing the version. i.e. is this a major,
 minor, or patch fix.
+
+Do you want to help out, but you're not sure how? :doc:`/source/contact`

--- a/docs/source/existing_project.rst
+++ b/docs/source/existing_project.rst
@@ -19,11 +19,7 @@ when attempting to incorporate the LINCC Frameworks Python Project Template
 into a pre-existing project. 
 
 We're here to help though! We have called out some gotchas below and we want to 
-hear from you if you encounter problems. Feel free to start a discussion here: 
-https://github.com/lincc-frameworks/python-project-template/discussions
-
-We'll respond there as quickly as possible, and hopefully the results will help 
-others along too!
+hear from you if you encounter problems. Feel free to :doc:`/source/contact`
 
 Newer projects are easier to upgrade
 ....................................
@@ -237,3 +233,8 @@ Benchmarking
 If your project wasn't using benchmarking before, and you chose to include it, please 
 make sure you follow the instructions under :doc:`Continuous Integration Benchmarking <../practices/ci_benchmarking>`
 to conclude the setup.
+
+Still have questions?
+----------------------------------------
+
+:doc:`/source/contact`

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -166,16 +166,22 @@ Additional configurations
 Configure your GitHub repository for safety and security
 ********************************************************
 
-Consider setting up branch protection rules. (`GitHub Instructions <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging>`_)
-This will help ensure your code is always ready to deploy by running all tests
-pass to merging into the ``main`` branch.
+* Consider setting up branch protection rules.
 
-Enable ``dependabot`` for your new repository. (`GitHub Instructions <https://docs.github.com/en/code-security/getting-started/securing-your-repository#managing-dependabot-security-updates>`_)
-There are several different features that ``dependabot`` offers to keep your dependencies
-up to date and your code secure. It's as easy as clicking a checkbox to get started.
+  * `GitHub Instructions for protected branches <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging>`_
+  * This will help ensure your code is always ready to deploy by running all tests
+    pass to merging into the ``main`` branch.
 
-Add another GitHub user as an administrator on your repository (`GitHub Instructions <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository>`_).
-It's just a good idea - like having a spare set of keys for your Lamborghini.
+* Enable ``dependabot`` for your new repository
+
+  * `GitHub Instructions for dependabot <https://docs.github.com/en/code-security/getting-started/securing-your-repository#managing-dependabot-security-updates>`_
+  * There are several different features that ``dependabot`` offers to keep your dependencies
+    up to date and your code secure. It's as easy as clicking a checkbox to get started.
+
+* Add another GitHub user as an administrator on your repository
+
+  * `GitHub Instructions for repo access <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository>`_
+  * It's just a good idea - like having a spare set of keys for your Lamborghini.
 
 Get the most out of this template
 *********************************
@@ -188,3 +194,8 @@ for more information.
 
 Finally, take a look at the :doc:`Best Practices section <../practices/overview>` to learn about
 built in pre-commit hooks, GitHub CI, automatic documentation, and more.
+
+Still have questions?
+-------------------------------------------------------------------------------
+
+:doc:`/source/contact`

--- a/docs/source/update_project.rst
+++ b/docs/source/update_project.rst
@@ -136,3 +136,9 @@ The maintainers of Copier have written good instructions and there's no point
 in reproducing it all here. 
 For all the details about updating with Copier checkout the 
 `original documentation <https://copier.readthedocs.io/en/latest/updating/>`_.
+
+
+Still have questions?
+-------------------------------------
+
+:doc:`/source/contact`


### PR DESCRIPTION
## Change Description

Closes #349 .

Also
- fixes the link from the README badge to link to the readthedocs
- addresses sphinx warning for multiple "github instructions" targets

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests