### PR TITLE
Add support for `asv-pr` on forked repositories

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -1,3 +1,4 @@
+{%- raw -%}
 # This workflow will run benchmarks with airspeed velocity (asv), 
 # store the new results in the "benchmarks" branch and publish them
 # to a dashboard on GH Pages.
@@ -10,10 +11,10 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-  WORKING_DIR: {% raw %}${{ github.workspace }}{% endraw %}/benchmarks
+  WORKING_DIR: ${{ github.workspace }}/benchmarks
 
 concurrency:
-  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -22,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cache Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: python-{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+          key: python-${{ env.PYTHON_VERSION }}
 
-      - name: Set up Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: "{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}"
+          python-version: "${{ env.PYTHON_VERSION }}"
 
   asv-main:
     runs-on: ubuntu-latest
@@ -42,7 +43,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: {% raw %}${{ env.WORKING_DIR }}{% endraw %}
+        working-directory: ${{ env.WORKING_DIR }}
 
     steps:
       - name: Checkout main branch of the repository
@@ -50,11 +51,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: python-{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+          key: python-${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: |
@@ -86,7 +87,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: benchmarks
-          folder: {% raw %}${{ env.WORKING_DIR }}{% endraw %}/_results
+          folder: ${{ env.WORKING_DIR }}/_results
           target-folder: _results
 
       - name: Generate dashboard HTML
@@ -98,4 +99,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: {% raw %}${{ env.WORKING_DIR }}{% endraw %}/_html
+          folder: ${{ env.WORKING_DIR }}/_html
+{%- endraw -%}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
@@ -1,3 +1,4 @@
+{%- raw -%}
 # This workflow will run daily at 06:45.
 # It will run benchmarks with airspeed velocity (asv)
 # and compare performance with the previous nightly build.
@@ -11,7 +12,7 @@ on:
   
 env:
   PYTHON_VERSION: "3.10"
-  WORKING_DIR: {% raw %}${{ github.workspace }}{% endraw %}/benchmarks
+  WORKING_DIR: ${{ github.workspace }}/benchmarks
   NIGHTLY_HASH_FILE: nightly-hash
 
 jobs:
@@ -21,7 +22,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: {% raw %}${{ env.WORKING_DIR }}{% endraw %}
+        working-directory: ${{ env.WORKING_DIR }}
 
     steps:
       - name: Checkout main branch of the repository
@@ -29,16 +30,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+      - name: Cache Python ${{ env.PYTHON_VERSION }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: python-{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+          key: python-${{ env.PYTHON_VERSION }}
 
-      - name: Set up Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: "{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}"
+          python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install dependencies
         run: |
@@ -72,13 +73,13 @@ jobs:
       - name: Use last nightly commit hash from cache
         uses: actions/cache@v3
         with:
-          path: {% raw %}${{ env.WORKING_DIR }}{% endraw %}
-          key: nightly-results-{% raw %}${{ steps.nightly-dates.outputs.yesterday }}{% endraw %}
+          path: ${{ env.WORKING_DIR }}
+          key: nightly-results-${{ steps.nightly-dates.outputs.yesterday }}
 
       - name: Run comparison of main against last nightly build
         run: |
-          HASH_FILE={% raw %}${{ env.NIGHTLY_HASH_FILE }}{% endraw %}
-          CURRENT_HASH={% raw %}${{ github.sha }}{% endraw %}
+          HASH_FILE=${{ env.NIGHTLY_HASH_FILE }}
+          CURRENT_HASH=${{ github.sha }}
           if [ -f $HASH_FILE ]; then          
             PREV_HASH=$(cat $HASH_FILE)
             asv continuous $PREV_HASH $CURRENT_HASH --verbose || true
@@ -89,5 +90,6 @@ jobs:
       - name: Update last nightly hash in cache
         uses: actions/cache@v3
         with:
-          path: {% raw %}${{ env.WORKING_DIR }}{% endraw %}
-          key: nightly-results-{% raw %}${{ steps.nightly-dates.outputs.today }}{% endraw %}
+          path: ${{ env.WORKING_DIR }}
+          key: nightly-results-${{ steps.nightly-dates.outputs.today }}
+{%- endraw -%}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -1,7 +1,9 @@
 {%- raw -%}
 # This workflow will run benchmarks with airspeed velocity (asv) for pull requests.
 # It will compare the performance of the main branch with the performance of the merge
-# with the new changes and publish a comment with this assessment.
+# with the new changes. It then publishes a comment with this assessment by triggering
+# the publish-benchmarks-pr workflow.
+# Based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
 name: Run benchmarks for PR
 
 on:

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -1,101 +1,86 @@
+{%- raw -%}
 # This workflow will run benchmarks with airspeed velocity (asv) for pull requests.
 # It will compare the performance of the main branch with the performance of the merge
-# with the new changes and publish a comment with this assessment.  
-
-name: Run ASV benchmarks for PR
+# with the new changes and publish a comment with this assessment.
+name: Run benchmarks for PR
 
 on:
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   PYTHON_VERSION: "3.10"
-  WORKING_DIR: {% raw %}${{ github.workspace }}{% endraw %}/benchmarks
-
-concurrency:
-  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
-  cancel-in-progress: true
+  WORKING_DIR: ${{ github.workspace }}/benchmarks
+  ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
 
 jobs:
-
   setup-python:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Cache Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: python-{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
-
-      - name: Set up Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
-        uses: actions/setup-python@v4
-        with:
-          python-version: "{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}"
-
+    - name: Cache Python ${{ env.PYTHON_VERSION }}
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: python-${{ env.PYTHON_VERSION }}
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
   asv-pr:
     runs-on: ubuntu-latest
     needs: setup-python
-
-    permissions:
-      actions: read
-      pull-requests: write
-
     defaults:
       run:
-        working-directory: {% raw %}${{ env.WORKING_DIR }}{% endraw %}
-
+        working-directory: ${{ env.WORKING_DIR }}
     steps:
-      - name: Checkout PR branch of the repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Cache Python {% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: python-{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          python -m pip install --upgrade pip
-          pip install asv==0.6.1 virtualenv tabulate lf-asv-formatter
-
-      - name: Get current job logs URL
-        uses: Tiryoh/gha-jobid-action@v0
-        id: jobs
-        with:
-          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-          job_name: {% raw %}${{ github.job }}{% endraw %}
-
-      - name: Create ASV machine config file
-        run: asv machine --machine gh-runner --yes
-
-      - name: Run comparison of PR against main branch
-        run: |
-          git remote add upstream https://github.com/{% raw %}${{ github.repository }}{% endraw %}.git
-          git fetch upstream
-          asv continuous upstream/main HEAD --verbose || true
-          asv compare upstream/main HEAD --sort ratio --verbose | tee output
-          python -m lf_asv_formatter --asv_version "$(echo asv --version)"
-          printf "\n\nClick [here]($STEP_URL) to view all benchmarks." >> output
-        env:
-          STEP_URL: "{% raw %}${{ steps.jobs.outputs.html_url }}{% endraw %}#step:8:1"
-
-      - name: Find benchmarks comment
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: {% raw %}${{ github.event.pull_request.number }}{% endraw %}
-          comment-author: 'github-actions[bot]'
-          body-includes: view all benchmarks
-
-      - name: Create or update benchmarks comment
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          comment-id: {% raw %}${{ steps.find-comment.outputs.comment-id }}{% endraw %}
-          issue-number: {% raw %}${{ github.event.pull_request.number }}{% endraw %}
-          body-path: {% raw %}${{ env.WORKING_DIR }}/output{% endraw %}
-          edit-mode: replace
+    - name: Checkout PR branch of the repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Display Workflow Run Information
+      run: |
+        echo "Workflow Run ID: ${{ github.run_id }}"
+    - name: Cache Python ${{ env.PYTHON_VERSION }}
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: python-${{ env.PYTHON_VERSION }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        python -m pip install --upgrade pip
+        pip install asv==0.6.1 virtualenv tabulate lf-asv-formatter
+    - name: Make artifacts directory
+      run: mkdir -p ${{ env.ARTIFACTS_DIR }}
+    - name: Save pull request number
+      run: echo ${{ github.event.pull_request.number }} > ${{ env.ARTIFACTS_DIR }}/pr
+    - name: Get current job logs URL
+      uses: Tiryoh/gha-jobid-action@v0
+      id: jobs
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        job_name: ${{ github.job }}
+    - name: Create ASV machine config file
+      run: asv machine --machine gh-runner --yes
+    - name: Save comparison of PR against main branch
+      run: |
+        git remote add upstream https://github.com/${{ github.repository }}.git
+        git fetch upstream
+        asv continuous upstream/main HEAD --verbose || true
+        asv compare upstream/main HEAD --sort ratio --verbose | tee output
+        python -m lf_asv_formatter --asv_version "$(echo asv --version)"
+        printf "\n\nClick [here]($STEP_URL) to view all benchmarks." >> output
+        mv output ${{ env.ARTIFACTS_DIR }}
+      env:
+        STEP_URL: "${{ steps.jobs.outputs.html_url }}#step:11:1"
+    - name: Upload artifacts (PR number and benchmarks output)
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-artifacts
+        path: ${{ env.ARTIFACTS_DIR }}
+{%- endraw -%}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
@@ -1,0 +1,55 @@
+{%- raw -%}
+# This workflow publishes a benchmarks comment to a PR.
+# It is triggered after the benchmarks are computed in the asv-pr workflow.
+# This separation of concerns allows us limit access to the target repository
+# private tokens and secrets, increasing the level of security.
+name: Publish benchmarks comment to PR
+
+on:
+  workflow_run:
+    workflows: ["Run benchmarks for PR"]
+    types: [completed]
+
+jobs:
+  upload-pr-comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - name: Display Workflow Run Information
+      run: |
+        echo "Workflow Run ID: ${{ github.event.workflow_run.id }}"
+        echo "Head SHA: ${{ github.event.workflow_run.head_sha }}"
+        echo "Head Branch: ${{ github.event.workflow_run.head_branch }}"
+        echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
+        echo "Event: ${{ github.event.workflow_run.event }}"
+    - name: Download artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        name: benchmark-artifacts
+        run_id: ${{ github.event.workflow_run.id }}
+    - name: Extract artifacts information
+      id: pr-info
+      run: |
+        printf "PR number: $(cat pr)\n"
+        printf "Output:\n$(cat output)"
+        printf "pr=$(cat pr)" >> $GITHUB_OUTPUT
+    - name: Find benchmarks comment
+      uses: peter-evans/find-comment@v2
+      id: find-comment
+      with:
+        issue-number: ${{ steps.pr-info.outputs.pr }}
+        comment-author: 'github-actions[bot]'
+        body-includes: view all benchmarks
+    - name: Create or update benchmarks comment
+      uses: peter-evans/create-or-update-comment@v3
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ steps.pr-info.outputs.pr }}
+        body-path: output
+        edit-mode: replace
+{%- endraw -%}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
@@ -1,8 +1,8 @@
 {%- raw -%}
-# This workflow publishes a benchmarks comment to a PR.
-# It is triggered after the benchmarks are computed in the asv-pr workflow.
-# This separation of concerns allows us limit access to the target repository
-# private tokens and secrets, increasing the level of security.
+# This workflow publishes a benchmarks comment on a pull request. It is triggered after the
+# benchmarks are computed in the asv-pr workflow. This separation of concerns allows us limit
+# access to the target repository private tokens and secrets, increasing the level of security.
+# Based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
 name: Publish benchmarks comment to PR
 
 on:


### PR DESCRIPTION
This pull request patches the `asv-pr` workflow, to allow publishing benchmark comments from a fork. This issue arose for the first time on the macauff incubator (https://github.com/macauff/macauff/pull/70) and a solution was implemented. 

## Solution description

This implementation was based off of a [GitHub security lab document](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). We assume the repositories are publicly available.

1. **asv-pr.yml** is the workflow that computes benchmarks for PRs open against main. It creates a table with metrics and uploads both the PR number and the table output to the workflow artifacts.
2. **publish-benchmarks-pr.yml** is a second workflow that is triggered on each completed `asv-pr` workflow. It downloads the benchmark artifacts and publishes a comment on the target repository.

(1) runs on a unprivileged environment and (2) runs on a privileged environment. This feature was tested more recently on a demo repository (https://github.com/lincc-frameworks/benchmarking-asv/pull/21).

### Why is this needed? 

The separation of concerns allows us to limit the access to the target repository private tokens and secrets, while allowing PRs from forks to post comments safely.

### Some additional clean-up

I did some clean-up (hopefully not too invasive!) because the workflows are becoming hard to read. Instead of constantly escaping variable access with `"{% raw %}" ... "{% endraw %}"`- because we want these to be resolved on the CI runner, not when running Jinja - I think it's safe to apply escaping to the workflow documents as a whole.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests