### PR TITLE
Add Ruff linting support

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -59,6 +59,7 @@ preferred_linter:
     choices:
         black: black
         pylint: pylint
+        ruff: ruff
         none: none
     when: "{{ custom_install }}"
 

--- a/docs/practices/linting.rst
+++ b/docs/practices/linting.rst
@@ -17,7 +17,7 @@ the code they're looking at adheres to that agreed-upon coding standard.
 A code reviewer won't be distracted by improper spacing, and can focus their 
 reviewing effort on the meat of the code.
 
-There are two main linters suggested by this template: pylint and black. While 
+There are three main linters suggested by this template: pylint, black, and ruff. While
 they have a lot of the same opinions, we recommend picking a single standard for 
 your project and sticking to it.
 If some folks use one linter, this may cause undue churn in your source files as
@@ -71,6 +71,20 @@ tool. The configuration for pylint is maintained in two ``.pylintrc`` files in
 the ``./src`` and ``./tests`` directories. This allows separate configurations
 for source versus test code. Take a look at the configuration documentation
 for pylint here: https://pylint.readthedocs.io/en/latest/user_guide/configuration/index.html
+
+
+Modifying ruff
+.................
+
+`Ruff <https://docs.astral.sh/ruff/>`_ is a very performant and highly customizable linting
+tool. The configuration for ruff is maintained in the ``pyproject.toml`` file.
+Ruff has many rules split into groups that can be selected to use when checking code.
+By default, we mostly follow the set of rules suggested by the
+`ruff documentation <https://docs.astral.sh/ruff/linter/#rule-selection>`_, with a few extra
+rules as suggested by
+`Rubin Data Management <https://developer.lsst.io/python/style.html#ruff-configuration-files>`_.
+For more information on configuration, see ruff's documentation here:
+https://docs.astral.sh/ruff/configuration/
 
 How to switch or remove linters
 -------------------------------

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -56,8 +56,9 @@ questions:
    * - *What tooling would you like to use to enforce code style?*
      - A linter is a tool to automatically format for consistency (see :doc:`Linting <../practices/linting>`). 
        We provide options for `black <https://black.readthedocs.io/en/stable/>`_, 
-       `pylint <https://pypi.org/project/pylint/>`_, or no linter. Choosing a linter will include it as a 
-       project dependency and include it in the :doc:`pre-commit <../practices/precommit>` hooks. 
+       `pylint <https://pypi.org/project/pylint/>`_, `ruff <https://docs.astral.sh/ruff/>`_ or no linter.
+       Choosing a linter will include it as a project dependency and include it in the
+       :doc:`pre-commit <../practices/precommit>` hooks.
        Defaults to ``pylint`` during simple installation. 
    * - *Do you want to use isort to maintain a specific ordering for module imports?*
      - `isort <https://pycqa.github.io/isort/>`_ is a tool for ordering imports in a standard order. 

--- a/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if preferred_linter != 'none' %}linting.yml{% endif %}.jinja
@@ -41,4 +41,7 @@ jobs:
       uses: psf/black@stable
       with:
         src: ./src
+{%- elif preferred_linter == 'ruff' %}
+      run: |
+        ruff check --output-format=github .
 {%- endif %}

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -99,6 +99,13 @@ repos:
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
+{% elif preferred_linter == 'ruff' %}
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.3
+    hooks:
+      - id: ruff
+        types_or: [ python, pyi, jupyter ]
 {% endif %}
 
 {% if mypy_type_checking != 'none' %}

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -92,8 +92,11 @@ target-version = "py38"
 select = [
     # pycodestyle
     "E",
+    "W",
     # Pyflakes
     "F",
+    # pep8-naming
+    "N",
     # pyupgrade
     "UP",
     # flake8-bugbear

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -105,8 +105,6 @@ select = [
     "I",
     # pep8 naming,
     "N",
-    # docstyle,
-    "D"
 ]
 {%- endif %}
 {%- if mypy_type_checking != 'none' %}

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -42,6 +42,8 @@ dev = [
     "pylint", # Used for static linting of files
 {%- elif preferred_linter == 'black' %}
     "black", # Used for static linting of files
+{%- elif preferred_linter == 'ruff' %}
+    "ruff", # Used for static linting of files
 {%- endif %}
 {%- if mypy_type_checking != 'none' %}
     "mypy", # Used for static type checking of files
@@ -82,6 +84,13 @@ target-version = ["py38"]
 profile = "black"
 line_length = 110
 
+{%- elif preferred_linter == 'ruff' %}
+
+[tool.ruff]
+line-length = 110
+target-version = ["py38"]
+
+{%- endif %}
 {%- if mypy_type_checking != 'none' %}
 [tool.setuptools.package-data]
 {{package_name}} = ["py.typed"]

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -89,7 +89,25 @@ line_length = 110
 [tool.ruff]
 line-length = 110
 target-version = "py38"
-
+select = [
+    # pycodestyle
+    "E",
+    "W",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # pep8 naming,
+    "N",
+    # docstyle,
+    "D"
+]
 {%- endif %}
 {%- if mypy_type_checking != 'none' %}
 [tool.setuptools.package-data]

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -92,7 +92,6 @@ target-version = "py38"
 select = [
     # pycodestyle
     "E",
-    "W",
     # Pyflakes
     "F",
     # pyupgrade
@@ -103,8 +102,6 @@ select = [
     "SIM",
     # isort
     "I",
-    # pep8 naming,
-    "N",
 ]
 {%- endif %}
 {%- if mypy_type_checking != 'none' %}

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -84,11 +84,11 @@ target-version = ["py38"]
 profile = "black"
 line_length = 110
 
-{%- elif preferred_linter == 'ruff' %}
+{%- if preferred_linter == 'ruff' %}
 
 [tool.ruff]
 line-length = 110
-target-version = ["py38"]
+target-version = "py38"
 
 {%- endif %}
 {%- if mypy_type_checking != 'none' %}


### PR DESCRIPTION
## Change Description

Adds the option to use the Ruff linter. If selected, adds the appropriate pre-commit hook, GitHub Action check, and config to the pyproject.toml

I'm a bit unsure about what rules to use here. There are [lots of rules Ruff has](https://docs.astral.sh/ruff/rules/) that are split up into groups you can select to apply in the config. I found the default option (specifying nothing in the config) to be pretty weak (doesn't even catch a line length too long). They give on their site an [example configuration](https://docs.astral.sh/ruff/linter/#rule-selection) with popular rules, and I've added that as the default config in pyproject.toml, but this is still a lot weaker than the pylint config we use in our projects. (Doesn't check docstrings or variable names, or whitespace). If we switch to using it in our projects, which I think I'd like to try, It will definitely need some more configuring of the rules, but I don't know how much we want to set that as a default for the template.

Closes #122 

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests