### PR TITLE
Support Git version on Macs

### DIFF
--- a/python-project-template/.prepare_project.sh
+++ b/python-project-template/.prepare_project.sh
@@ -2,7 +2,7 @@
 
 echo "Initializing local git repository"
 {
-    gitversion=( $(git version | sed 's/^.* //;s/\./ /g') )
+    gitversion=( $(git version | git version | awk '{print $3}' | sed 's/\./ /g') )
     if let "${gitversion[0]}<2"; then
 	# manipulate directly
 	git init . && echo 'ref: refs/heads/main' >.git/HEAD


### PR DESCRIPTION
## Change Description

Addresses #327 to correct parse the git version on macs.  See the issues for details on the fix.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests