### PR TITLE
Have prepare_project exit on old versions of pip

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -31,10 +31,11 @@ natively supports updating projects as the original template matures.
 It's really neat!
 
 .. important::
-    Copier has two requirements and one recommended tool:
+    Copier has a few requirements and one recommended tool:
 
     #. Python > 3.7 **required**
     #. Git > 2.27 **required**
+    #. pip >= 22 **required**
     #. pipx *recommended*
 
     Learn how to maintain a clean Python environment with ``pipx``
@@ -51,6 +52,9 @@ It's really neat!
 
         >> git --version
             git version 2.34.1
+
+        >> pip --version
+            pip 23.3.1 from _____
 
         >> which pipx
             /usr/bin/pipx

--- a/python-project-template/.prepare_project.sh
+++ b/python-project-template/.prepare_project.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 echo "Checking pip version"
+MINIMUM_PIP_VERSION=22
 pipversion=( $(pip --version | awk '{print $2}' | sed 's/\./ /g') )
-if let "${pipversion[0]}<22"; then
-    echo "Insufficient version of pip found. Requires at least version 22."
+if let "${pipversion[0]}<${MINIMUM_PIP_VERSION}"; then
+    echo "Insufficient version of pip found. Requires at least version ${MINIMUM_PIP_VERSION}."
     echo "See https://lincc-ppt.readthedocs.io/ for details."
     exit 1
 fi

--- a/python-project-template/.prepare_project.sh
+++ b/python-project-template/.prepare_project.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+echo "Checking pip version"
+pipversion=( $(pip --version | awk '{print $2}' | sed 's/\./ /g') )
+if let "${pipversion[0]}<22"; then
+    echo "Insufficient version of pip found. Requires at least version 22."
+    echo "See https://lincc-ppt.readthedocs.io/ for details."
+fi
+
 echo "Initializing local git repository"
 {
     gitversion=( $(git version | git version | awk '{print $3}' | sed 's/\./ /g') )

--- a/python-project-template/.prepare_project.sh
+++ b/python-project-template/.prepare_project.sh
@@ -5,6 +5,7 @@ pipversion=( $(pip --version | awk '{print $2}' | sed 's/\./ /g') )
 if let "${pipversion[0]}<22"; then
     echo "Insufficient version of pip found. Requires at least version 22."
     echo "See https://lincc-ppt.readthedocs.io/ for details."
+    exit 1
 fi
 
 echo "Initializing local git repository"


### PR DESCRIPTION
## Change Description

Closes #333. Check the version of pip at the start of `.prepare_project.sh` and exit if the user is not using at least version 22.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests