### PR TITLE
Use `tox` to run `pytest-copie` unit tests locally on multiple python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pre-commit", # Used to run checks prior to committing code
     "pytest", # Used to run tests
     "pytest-copie", # Used to create hydrated copier projects for testing
+    "tox", # Used to run tests in multiple environments
 ]
 
 [build-system]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{38, 39, 310, 311}
+
+[testenv]
+deps =
+    pytest
+    pytest-copie
+    black
+    pylint
+commands =
+    pytest tests
+


### PR DESCRIPTION
## Change Description
This proof of concept PR shows that we can use tox with a simple configuration file to execute the `pytest-copie`-based unit tests locally on a group a set of different python versions. 

There's a fair amount of dev environment setup that is required:

1. Install `tox` in your working environment.
2. Install `pyenv` - typically this is done with `brew install pyenv`. 
3. Run `pyenv init` to see what updates to make to your .bashrc file to finish the installation. 
More instructions for pyenv install and setup are here: https://github.com/pyenv/pyenv?tab=readme-ov-file#installation

With `pyenv` installed you can now install multiple versions of python. Note however, that pyenv actually _builds_ python on your system, so you need to make sure that you have the python build dependencies installed as well. Instructions for doing that are here: https://devguide.python.org/getting-started/setup-building/#install-dependencies

4. You can now build and install various versions of python like so `pyenv install 3.11`.
5. You can also run `pyenv versions` to see the versions of python that are available. Note that this doesn't include the python in your conda environment, or the default system python version. 
6. Now from the command line, change to the directory that has the tox.ini file in it.
7. Run `pyenv local 3.11.7` so that the version of python is "available" (i.e. it can be discovered by tox)
8. Run `tox`. 

The output from the configuration file here will show that it tries to find python versions 3.8-3.11. For each version that tox finds, it will run `pytest tests` and report the results. 


## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests