### PR TITLE
Removing hardcoded `tests` path from invocations of pytest.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,4 +148,4 @@ jobs:
       if: ${{ !contains(matrix.copier_config.extra_flags, 'create_example_module=no') }}
       run: |
         cd ../test/${{ matrix.copier_config.foldername }}
-        python -m pytest tests --cov=${{ matrix.copier_config.package_name }} --cov-report=xml
+        python -m pytest --cov=${{ matrix.copier_config.package_name }} --cov-report=xml

--- a/python-project-template/.github/workflows/smoke-test.yml
+++ b/python-project-template/.github/workflows/smoke-test.yml
@@ -40,4 +40,4 @@ jobs:
         pip list
     - name: Run unit tests with pytest
       run: |
-        python -m pytest tests
+        python -m pytest

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -32,6 +32,6 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run unit tests with pytest
       run: |
-        python -m pytest tests --cov={{package_name}} --cov-report=xml
+        python -m pytest --cov={{package_name}} --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v3

--- a/tests/test_package_creation.py
+++ b/tests/test_package_creation.py
@@ -45,7 +45,7 @@ def unit_tests_in_project_run_successfully(result, package_name = "example_packa
     virtual environment for the project.
     """
     pytest_results = subprocess.run(
-        ["python", "-m", "pytest", (result.project_dir / f"tests/{package_name}")],
+        ["python", "-m", "pytest"],
         cwd=result.project_dir
     )
 


### PR DESCRIPTION
## Change Description
- Removed the hard coded `tests` path from the hydrated project's CI workflows. 
- Removed the hard coded `tests` path from the CI for the PPT.
- Removed the hard coded `tests` path from the `pytest-copie` test (even though it's not currently used).



## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests