### PR TITLE
fix ruff config

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -89,6 +89,8 @@ line_length = 110
 [tool.ruff]
 line-length = 110
 target-version = "py38"
+
+[tool.ruff.lint]
 select = [
     # pycodestyle
     "E",
@@ -106,6 +108,7 @@ select = [
     # isort
     "I",
 ]
+ignore = []
 {%- if mypy_type_checking != 'none' %}
 [tool.setuptools.package-data]
 {{package_name}} = ["py.typed"]


### PR DESCRIPTION
## Change Description

Fixes the ruff config to use the correct config headings.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests