### PR TITLE
Adding default dependabot.yml file.

### DIFF
--- a/python-project-template/.github/dependabot.yml
+++ b/python-project-template/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Change Description
Introduces a simple default dependabot.yml file.


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests