### PR TITLE
Issue/363/issue template

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ please :doc:`/source/contact`
    practices/ci_testing
    practices/code_coverage
    practices/git-lfs
+   pracices/issue_pr_templating
    practices/linting
    practices/namespace_project
    practices/pipx

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ please :doc:`/source/contact`
    practices/ci_testing
    practices/code_coverage
    practices/git-lfs
-   pracices/issue_pr_templating
+   practices/issue_pr_templating
    practices/linting
    practices/namespace_project
    practices/pipx

--- a/docs/practices/issue_pr_templating.rst
+++ b/docs/practices/issue_pr_templating.rst
@@ -31,7 +31,7 @@ Modifying using the Github Web-Interface
 Github offers native support for adding and modifying issue templates directly
 in it's web-interface. This is done within the settings menu, and Github has a
 straightforward guide on how to access this interface, 
-`here <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository>`_
+`here <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository>`_.
 
 Changing Template Ordering
 ...............................................................................

--- a/docs/practices/issue_pr_templating.rst
+++ b/docs/practices/issue_pr_templating.rst
@@ -1,0 +1,66 @@
+Issue and Pull Request Templates
+===============================================================================
+
+What is it? Why do it?
+-------------------------------------------------------------------------------
+
+Issues and Pull Requests form the core of developer-community communication
+regarding identified problems/requested features and their implementation in
+a given software package. The main function of templates, is to provide
+guidelines on the content of these, usually focused on ensuring a given
+user/developer provides enough context in a given issue/pull request (PR) for 
+others to understand the motivation and technical details.
+
+Issue Templates
+-------------------------------------------------------------------------------
+
+Issue templates are highly customizable, and it's often appropriate to have
+multiple available to users to promote better organization of common issue
+types. By default, the python-project-template provides three base templates
+
+- **general-issue-template**: A general issue template for issues that don't 
+fit into other categories
+- **bug-report-template**: A template specific to identifying bugs within the
+package
+- **feature-request-template**: A template for requesting new features of the
+package
+
+A user will be prompted to choose between these templates any time they attempt
+to create a new issue in the repository. You may add to new templates to this 
+list as additional common issue themes become clear in your project.
+
+Modifying using the Github Web-Interface
+...............................................................................
+Github offers native support for adding and modifying issue templates directly
+in it's web-interface. This is done within the settings menu, and Github has a
+straightforward guide on how to access this interface, 
+`here <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository>`
+
+Changing Template Ordering
+...............................................................................
+The ordering of issue templates is controlled by alpha-numeric names of the
+template files themselves. To best control ordering, it's recommended to prefix
+the template files with a number (e.g. ``0-first_template.md``, 
+``1-second_template.md``, etc.). This is also covered in it's own section of
+the `github issue templating guide <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#changing-the-order-of-templates>`.
+
+.. note::
+    The issue template files can be found in the ``.github/ISSUE_TEMPLATE`` 
+    subdirectory of your repository.
+
+Pull Request Template
+-------------------------------------------------------------------------------
+
+A pull request template is used to pre-populate any submitted PRs to the
+repository. By default, the python-project-template provides a single template
+to the project (located at ``.github/pull_request_template.md``). This template
+provides generic fields for:
+
+- **Change Description**: Prompt for overview of what the PR changes
+- **Solution Description**: Prompt for technical details of the solution
+- **Code Quality**: Checkboxes to verify that the PR adheres to the coding
+standards of the repository
+
+As well as a set of additional project and issue-specific fields. This template
+only serves as an initial framework, and you should feel free to modify this as
+you see fit by directly modifying the template file.

--- a/docs/practices/issue_pr_templating.rst
+++ b/docs/practices/issue_pr_templating.rst
@@ -23,7 +23,7 @@ types. By default, the python-project-template provides three base templates
 * **feature-request-template**: A template for requesting new features of the package.
 
 A user will be prompted to choose between these templates any time they attempt
-to create a new issue in the repository. You may add to new templates to this 
+to create a new issue in the repository. You may add new templates to this 
 list as additional common issue themes become clear in your project.
 
 Modifying using the Github Web-Interface

--- a/docs/practices/issue_pr_templating.rst
+++ b/docs/practices/issue_pr_templating.rst
@@ -6,7 +6,7 @@ What is it? Why do it?
 
 Issues and Pull Requests form the core of developer-community communication
 regarding identified problems/requested features and their implementation in
-a given software package. The main function of templates, is to provide
+a given software package. The main function of templates is to provide
 guidelines on the content of these, usually focused on ensuring a given
 user/developer provides enough context in a given issue/pull request (PR) for 
 others to understand the motivation and technical details.
@@ -18,12 +18,9 @@ Issue templates are highly customizable, and it's often appropriate to have
 multiple available to users to promote better organization of common issue
 types. By default, the python-project-template provides three base templates
 
-- **general-issue-template**: A general issue template for issues that don't 
-fit into other categories
-- **bug-report-template**: A template specific to identifying bugs within the
-package
-- **feature-request-template**: A template for requesting new features of the
-package
+* **general-issue-template**: A general issue template for issues that don't fit into other categories.
+* **bug-report-template**: A template specific to identifying bugs within the package.
+* **feature-request-template**: A template for requesting new features of the package.
 
 A user will be prompted to choose between these templates any time they attempt
 to create a new issue in the repository. You may add to new templates to this 
@@ -34,7 +31,7 @@ Modifying using the Github Web-Interface
 Github offers native support for adding and modifying issue templates directly
 in it's web-interface. This is done within the settings menu, and Github has a
 straightforward guide on how to access this interface, 
-`here <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository>`
+`here <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository>`_
 
 Changing Template Ordering
 ...............................................................................
@@ -42,7 +39,7 @@ The ordering of issue templates is controlled by alpha-numeric names of the
 template files themselves. To best control ordering, it's recommended to prefix
 the template files with a number (e.g. ``0-first_template.md``, 
 ``1-second_template.md``, etc.). This is also covered in it's own section of
-the `github issue templating guide <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#changing-the-order-of-templates>`.
+the `github issue templating guide <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#changing-the-order-of-templates>`_.
 
 .. note::
     The issue template files can be found in the ``.github/ISSUE_TEMPLATE`` 
@@ -56,10 +53,9 @@ repository. By default, the python-project-template provides a single template
 to the project (located at ``.github/pull_request_template.md``). This template
 provides generic fields for:
 
-- **Change Description**: Prompt for overview of what the PR changes
-- **Solution Description**: Prompt for technical details of the solution
-- **Code Quality**: Checkboxes to verify that the PR adheres to the coding
-standards of the repository
+* **Change Description**: Prompt for overview of what the PR changes
+* **Solution Description**: Prompt for technical details of the solution
+* **Code Quality**: Checkboxes to verify that the PR adheres to the coding standards of the repository
 
 As well as a set of additional project and issue-specific fields. This template
 only serves as an initial framework, and you should feel free to modify this as

--- a/python-project-template/.github/ISSUE_TEMPLATE/0-general_issue.md
+++ b/python-project-template/.github/ISSUE_TEMPLATE/0-general_issue.md
@@ -1,0 +1,8 @@
+---
+name: General issue
+about: Quickly create a general issue
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/python-project-template/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/python-project-template/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Tell us about a problem to fix
+title: 'Short description'
+labels: 'bug'
+assignees: ''
+
+---
+**Bug report**
+
+
+**Before submitting**
+Please check the following:
+
+- [ ] I have described the situation in which the bug arose, including what code was executed, information about my environment, and any applicable data others will need to reproduce the problem.
+- [ ] I have included available evidence of the unexpected behavior (including error messages, screenshots, and/or plots) as well as a descriprion of what I expected instead.
+- [ ] If I have a solution in mind, I have provided an explanation and/or pseudocode and/or task list.

--- a/python-project-template/.github/ISSUE_TEMPLATE/2-feature_request.md
+++ b/python-project-template/.github/ISSUE_TEMPLATE/2-feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'Short description'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+** Feature request**
+
+
+**Before submitting**
+Please check the following:
+
+- [ ] I have described the purpose of the suggested change, specifying what I need the enhancement to accomplish, i.e. what problem it solves.
+- [ ] I have included any relevant links, screenshots, environment information, and data relevant to implementing the requested feature, as well as pseudocode for how I want to access the new functionality.
+- [ ] If I have ideas for how the new feature could be implemented, I have provided explanations and/or pseudocode and/or task lists for the steps.


### PR DESCRIPTION
## Change Description
Adds the three issue templates created for the rail-ppt, and adds documentation on issue and PR templating. Addresses #363  

I chose to add the issue templates to the PPT as part of this PR, which is possibly outside the scope of #363. If it's preferable to just give users the documentation on how to generate these instead of creating some defaults, I'm more than happy to adjust this to do that.


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests