### PR TITLE
Add more correctness to code style workflow

### DIFF
--- a/python-project-template/.github/workflows/code_style.yml.jinja
+++ b/python-project-template/.github/workflows/code_style.yml.jinja
@@ -33,11 +33,11 @@ jobs:
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-{%- if mypy_type_checking == 'basic' -%}
+{%- if mypy_type_checking == 'basic' %}
     - name: Analyze code with mypy
       run: |
         mypy ./src ./tests --ignore-missing-imports
-{%- elif mypy_type_checking == 'strict' -%}
+{%- elif mypy_type_checking == 'strict' %}
     - name: Analyze code with mypy
       run: |
         mypy ./src ./tests --strict
@@ -58,6 +58,7 @@ jobs:
 {%- endif -%}
 {%- if 'ruff' in enforce_style %}
     - name: Analyze code with ruff
+      run: |
        ruff format --check
        ruff check
 {%- endif -%}


### PR DESCRIPTION
## Change Description

Closes #377. Adds newlines in a few places, and also the ` run: |` line before ruff commands.

Follow-up to https://github.com/lincc-frameworks/python-project-template/pull/372

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests