### PR TITLE
Use lowest available python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         copier_config:
           - name: Base example
             package_name: example_package # The default package_name

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
+requires-python = ">={{ python_versions[0] }}"
 dependencies = [
 {%- if include_notebooks %}
     "ipykernel", # Support for Jupyter notebooks
@@ -80,7 +81,7 @@ testpaths = [
 
 [tool.black]
 line-length = 110
-target-version = ["py38"]
+target-version = ["py{{ python_versions[0] | replace(".", "") }}"]
 
 [tool.isort]
 profile = "black"
@@ -88,7 +89,7 @@ line_length = 110
 
 [tool.ruff]
 line-length = 110
-target-version = "py38"
+target-version = "py{{ python_versions[0] | replace(".", "") }}"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Change Description

Uses the first element of the selection of python versions to populate some minimum required version support.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests