### PR TITLE
Bump action versions

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v0.5.0 # Still using Node 16
         with:
           # You can target a repository in a different organization
           # to the issue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,10 @@ jobs:
     steps:
     
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     

--- a/docs/practices/code_coverage.rst
+++ b/docs/practices/code_coverage.rst
@@ -21,4 +21,7 @@ install the GitHub app, Codecov.
 * Click "Configure"
 * Select your repository and follow the instructions
 
+On your Codecov repository click "Settings" and under "Tokens" copy the value of
+`CODECOV_TOKEN`. Add it as a secret on your GitHub repository and you're all set!
+
 Future pull requests and commits will now include code coverage information. Neato!

--- a/python-project-template/.github/workflows/code_style.yml.jinja
+++ b/python-project-template/.github/workflows/code_style.yml.jinja
@@ -21,9 +21,9 @@ jobs:
         python-version: {{ python_versions }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
     - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies

--- a/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
+++ b/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
@@ -13,11 +13,11 @@ jobs:
     env: 
       SKIP: "check-lincc-frameworks-template-version,pytest-check,no-commit-to-branch,validate-pyproject,check-added-large-files,sphinx-build"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
       with:
         fetch-depth: 0 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -27,8 +27,8 @@ jobs:
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@main # Still using Node 16
       with:
         extra_args: --from-ref {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %} --to-ref {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
-    - uses: pre-commit-ci/lite-action@v1.0.1
+    - uses: pre-commit-ci/lite-action@main
       if: always()

--- a/python-project-template/.github/workflows/publish-to-pypi.yml
+++ b/python-project-template/.github/workflows/publish-to-pypi.yml
@@ -22,9 +22,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/python-project-template/.github/workflows/smoke-test.yml.jinja
+++ b/python-project-template/.github/workflows/smoke-test.yml.jinja
@@ -44,7 +44,7 @@ jobs:
 {%- if 'email' in failure_notification %}
     - name: Send status to author's email      
       if: {% raw %}${{ failure() }} && github.event_name != 'workflow_dispatch' }}{% endraw %} # Only email if the workflow failed and was not manually started. Customize this as necessary.
-      uses: dawidd6/action-send-mail@main
+      uses: dawidd6/action-send-mail@master
       with:
         # Required mail server address if not connection_url:
         server_address: smtp.gmail.com

--- a/python-project-template/.github/workflows/smoke-test.yml.jinja
+++ b/python-project-template/.github/workflows/smoke-test.yml.jinja
@@ -23,9 +23,9 @@ jobs:
         python-version: {{ python_versions }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
     - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
 {%- if 'email' in failure_notification %}
     - name: Send status to author's email      
       if: {% raw %}${{ failure() }} && github.event_name != 'workflow_dispatch' }}{% endraw %} # Only email if the workflow failed and was not manually started. Customize this as necessary.
-      uses: dawidd6/action-send-mail@v3
+      uses: dawidd6/action-send-mail@main
       with:
         # Required mail server address if not connection_url:
         server_address: smtp.gmail.com
@@ -81,7 +81,7 @@ jobs:
     - name: Send status to Slack app
       if: {% raw %}${{ failure() && github.event_name != 'workflow_dispatch' }}{% endraw %} # Only post if the workflow failed and was not manually started. Customize this as necessary.
       id: slack
-      uses: slackapi/slack-github-action@v1.24.0
+      uses: slackapi/slack-github-action@main
       with:
         # For posting a rich message using Block Kit
         payload: | # The payload defined here can be customized to you liking https://api.slack.com/reference/block-kit/blocks 

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -35,3 +35,5 @@ jobs:
         python -m pytest --cov={{package_name}} --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@main
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -18,9 +18,9 @@ jobs:
         python-version: {{ python_versions }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
     - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies
@@ -34,4 +34,4 @@ jobs:
       run: |
         python -m pytest --cov={{package_name}} --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@main

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -36,4 +36,4 @@ jobs:
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@main
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Cache Python ${{ env.PYTHON_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@main
         with:
           path: ~/.cache/pip
           key: python-${{ env.PYTHON_VERSION }}
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@main
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Checkout main branch of the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
 
       - name: Cache Python ${{ env.PYTHON_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@main
         with:
           path: ~/.cache/pip
           key: python-${{ env.PYTHON_VERSION }}
@@ -84,7 +84,7 @@ jobs:
         run: asv run ALL --skip-existing --verbose || true
 
       - name: Submit new results to the "benchmarks" branch
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@main
         with:
           branch: benchmarks
           folder: ${{ env.WORKING_DIR }}/_results
@@ -96,7 +96,7 @@ jobs:
           asv publish
 
       - name: Deploy to Github pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@main
         with:
           branch: gh-pages
           folder: ${{ env.WORKING_DIR }}/_html

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -84,7 +84,7 @@ jobs:
         run: asv run ALL --skip-existing --verbose || true
 
       - name: Submit new results to the "benchmarks" branch
-        uses: JamesIves/github-pages-deploy-action@main
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: benchmarks
           folder: ${{ env.WORKING_DIR }}/_results
@@ -96,7 +96,7 @@ jobs:
           asv publish
 
       - name: Deploy to Github pages
-        uses: JamesIves/github-pages-deploy-action@main
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: ${{ env.WORKING_DIR }}/_html

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: Checkout main branch of the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
 
       - name: Cache Python ${{ env.PYTHON_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@main
         with:
           path: ~/.cache/pip
           key: python-${{ env.PYTHON_VERSION }}
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@main
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -71,7 +71,7 @@ jobs:
           echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Use last nightly commit hash from cache
-        uses: actions/cache@v3
+        uses: actions/cache@main
         with:
           path: ${{ env.WORKING_DIR }}
           key: nightly-results-${{ steps.nightly-dates.outputs.yesterday }}
@@ -88,7 +88,7 @@ jobs:
           echo $CURRENT_HASH > $HASH_FILE
 
       - name: Update last nightly hash in cache
-        uses: actions/cache@v3
+        uses: actions/cache@main
         with:
           path: ${{ env.WORKING_DIR }}
           key: nightly-results-${{ steps.nightly-dates.outputs.today }}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache Python ${{ env.PYTHON_VERSION }}
-      uses: actions/cache@v3
+      uses: actions/cache@main
       with:
         path: ~/.cache/pip
         key: python-${{ env.PYTHON_VERSION }}
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: ${{ env.PYTHON_VERSION }}
   asv-pr:
@@ -41,14 +41,14 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
     steps:
     - name: Checkout PR branch of the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@main
       with:
         fetch-depth: 0
     - name: Display Workflow Run Information
       run: |
         echo "Workflow Run ID: ${{ github.run_id }}"
     - name: Cache Python ${{ env.PYTHON_VERSION }}
-      uses: actions/cache@v3
+      uses: actions/cache@main
       with:
         path: ~/.cache/pip
         key: python-${{ env.PYTHON_VERSION }}
@@ -62,7 +62,7 @@ jobs:
     - name: Save pull request number
       run: echo ${{ github.event.pull_request.number }} > ${{ env.ARTIFACTS_DIR }}/pr
     - name: Get current job logs URL
-      uses: Tiryoh/gha-jobid-action@v0
+      uses: Tiryoh/gha-jobid-action@main
       id: jobs
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
       env:
         STEP_URL: "${{ steps.jobs.outputs.html_url }}#step:11:1"
     - name: Upload artifacts (PR number and benchmarks output)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@main
       with:
         name: benchmark-artifacts
         path: ${{ env.ARTIFACTS_DIR }}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
@@ -28,7 +28,7 @@ jobs:
         echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
         echo "Event: ${{ github.event.workflow_run.event }}"
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@main
       with:
         name: benchmark-artifacts
         run_id: ${{ github.event.workflow_run.id }}
@@ -39,14 +39,14 @@ jobs:
         printf "Output:\n$(cat output)"
         printf "pr=$(cat pr)" >> $GITHUB_OUTPUT
     - name: Find benchmarks comment
-      uses: peter-evans/find-comment@v2
+      uses: peter-evans/find-comment@main
       id: find-comment
       with:
         issue-number: ${{ steps.pr-info.outputs.pr }}
         comment-author: 'github-actions[bot]'
         body-includes: view all benchmarks
     - name: Create or update benchmarks comment
-      uses: peter-evans/create-or-update-comment@v3
+      uses: peter-evans/create-or-update-comment@main
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         issue-number: ${{ steps.pr-info.outputs.pr }}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
@@ -28,7 +28,7 @@ jobs:
         echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
         echo "Event: ${{ github.event.workflow_run.event }}"
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@main
+      uses: dawidd6/action-download-artifact@master
       with:
         name: benchmark-artifacts
         run_id: ${{ github.event.workflow_run.id }}

--- a/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@main
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: '3.10'
     - name: Install dependencies


### PR DESCRIPTION
Node 16 is coming to the end of life, in favor of Node 20. This bumps the versions of all the actions used by the template project. The workflows (except for those of PPT) are now pointing to the latest release of each action. 

## Some considerations

- The latest versions of `codecov/codecov-action` stopped supporting tokenless upload of code coverage reports. We are now required to add a `CODECOV_TOKEN` secret to our repositories.
- `pre-commit-ci/lite-action` is not on Node 20 yet but there's a PR under a review for that purpose.
- `JamesIves/github-pages-deploy-action` will remain on v4 because their development branch does not contain the deployed `lib/`.

Closes #358. 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests