### PR TITLE
Install project in dev mode for tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
         git init --initial-branch=main
         git add src
         git commit -m initial
-        pip install .
         pip install .[dev]
       
     - name: black checks

--- a/docs/source/existing_project.rst
+++ b/docs/source/existing_project.rst
@@ -150,7 +150,6 @@ or missing dependencies.
 
 .. code:: bash
 
-    >> pip install -e .
     >> pip install -e .'[dev]'
 
 .. note:: 

--- a/python-project-template/.github/workflows/code_style.yml.jinja
+++ b/python-project-template/.github/workflows/code_style.yml.jinja
@@ -30,7 +30,6 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 {%- if mypy_type_checking == 'basic' %}

--- a/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
+++ b/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
@@ -24,7 +24,6 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - uses: pre-commit/action@v3.0.0

--- a/python-project-template/.github/workflows/smoke-test.yml.jinja
+++ b/python-project-template/.github/workflows/smoke-test.yml.jinja
@@ -32,8 +32,7 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .
-        pip install .[dev]
+        pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: List dependencies
       run: |

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -27,8 +27,7 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .
-        pip install .[dev]
+        pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run unit tests with pytest
       run: |


### PR DESCRIPTION
Based on the fix @delucchi-cmu applied in https://github.com/lincc-frameworks/pandas-ts/pull/24. 

This pull request addresses issues running both unit tests in `tests/` and doctests in `src/`. The solution is to install the package in developer mode whenever running pytest. 

It also cleans some of the installation instructions that have `pip install .` followed by `pip install .[dev]`. 

Closes #381. 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests