### PR TITLE
Allow first commit to main

### DIFF
--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -121,9 +121,15 @@ script in your new project directory.
 
     >> bash .prepare_project.sh
 
-This script will initialize your local git repository then install the new Python
-package in editable mode along with runtime and developer dependencies. Finally
-the script will initialize :doc:`pre-commit <../practices/precommit>`.
+This script will initialize your local git repository, install the new Python
+package in editable mode along with runtime and developer dependencies, and
+initialize :doc:`pre-commit <../practices/precommit>`.
+
+.. important::
+    The script ends by creating a first commit to the initial branch with the template files.
+    If you added other files to the repository before running the script they will be subject
+    to the pre-commit hooks checks. If they are not compliant the bash script will exit
+    with a verbose error code. You should apply the suggestions and re-run the script.
 
 The full contents of the script can be seen on `Github <https://github.com/lincc-frameworks/python-project-template/tree/main/python-project-template/.prepare_project.sh>`_.
 

--- a/python-project-template/.prepare_project.sh
+++ b/python-project-template/.prepare_project.sh
@@ -32,3 +32,6 @@ pip install -e .'[dev]' > /dev/null
 
 echo "Installing pre-commit"
 pre-commit install > /dev/null
+
+echo "Committing initial files"
+git add . && SKIP="no-commit-to-branch" git commit -m "Initial commit"


### PR DESCRIPTION
This pull request solves an inconvenient issue about commits to main. With the current version of the template we install pre-commit hooks on the `.prepare_project` bash script. One of the hooks protects unintentional commits to `main`, which is extremely useful during development, but problematic when first creating a repository.

As a workaround, the last stage of the script now includes a commit to the initial branch and for that we skip the "no-commit-to-branch" hook. The documentation was updated accordingly. Closes #331.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests