### PR TITLE
Fix raw tags in slack notification config.

### DIFF
--- a/python-project-template/.github/workflows/smoke-test.yml.jinja
+++ b/python-project-template/.github/workflows/smoke-test.yml.jinja
@@ -76,9 +76,9 @@ jobs:
           {% endraw %}
 {%- endif %}
 {%- if 'slack' in failure_notification %}
-{%- raw %}
+    {%- raw %}
     - name: Send status to Slack app
-      if: {% raw %}${{ failure() && github.event_name != 'workflow_dispatch' }}{% endraw %} # Only post if the workflow failed and was not manually started. Customize this as necessary.
+      if: ${{ failure() && github.event_name != 'workflow_dispatch' }} # Only post if the workflow failed and was not manually started. Customize this as necessary.
       id: slack
       uses: slackapi/slack-github-action@main
       with:
@@ -115,4 +115,5 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Here is where the webhook URL is provided
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    {%- endraw %}
 {%- endif %}

--- a/tests/test_package_creation.py
+++ b/tests/test_package_creation.py
@@ -114,3 +114,20 @@ def test_use_black_and_no_example_modules(copie):
     assert found_line
 
     assert black_runs_successfully(result)
+
+
+def test_smoke_test_notification(copie):
+    """Confirm we can generate a "smoke_test.yaml" file, with all
+    notification mechanisms selected."""
+
+    # provide a dictionary of the non-default answers to use
+    extra_answers = {
+        "failure_notification": ["email", "slack"],
+    }
+
+    # run copier to hydrate a temporary project
+    result = copie.copy(extra_answers=extra_answers)
+
+    assert successfully_created_project(result)
+    assert directory_structure_is_correct(result)
+    assert black_runs_successfully(result)


### PR DESCRIPTION
## Change Description

Fixes an issue with opening/closing `raw` tags in the smoke test jinja.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests