### PR TITLE
Check virtual environment is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ copier copy gh:lincc-frameworks/python-project-template <path/to/destination>
 cd <path/to/destination>
 # Create a virtual environment, feel free to use conda, pyenv or your favorite tool
 python3 -mvenv ~/.virtualenvs/<env_name>
-source ~/.virtualenvs/<project_name>/bin/activate
+source ~/.virtualenvs/<env_name>/bin/activate
 bash .prepare_project.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Choose where you would like to create your new project, and call copier with the
 copier copy gh:lincc-frameworks/python-project-template <path/to/destination>
 cd <path/to/destination>
 # Create a virtual environment, feel free to use conda, pyenv or your favorite tool
-python3 -mvenv ~/.virtualenvs/<project_name>
+python3 -mvenv ~/.virtualenvs/<env_name>
 source ~/.virtualenvs/<project_name>/bin/activate
 bash .prepare_project.sh
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Choose where you would like to create your new project, and call copier with the
 ```sh
 copier copy gh:lincc-frameworks/python-project-template <path/to/destination>
 cd <path/to/destination>
+# Create a virtual environment, feel free to use conda, pyenv or your favorite tool
+python3 -mvenv ~/.virtualenvs/<project_name>
+source ~/.virtualenvs/<project_name>/bin/activate
 bash .prepare_project.sh
 ```
 

--- a/copier.yml
+++ b/copier.yml
@@ -147,9 +147,10 @@ include_benchmarks:
 _message_after_copy: |
     Your project "{{ project_name }}" has been created successfully!
 
-    Next, change directory to the project root and complete git configuration:
+    Next, change directory to the project root, create virtual environment, and complete git configuration:
 
        $ cd {{ _copier_conf.dst_path }}
+       $ python3 -mvenv ~/.virtualenvs/{{ project_name }} && source ~/.virtualenvs/{{ project_name }}/bin/activate
        $ bash .prepare_project.sh
 
 ###

--- a/python-project-template/.prepare_project.sh
+++ b/python-project-template/.prepare_project.sh
@@ -3,8 +3,16 @@
 echo "Checking virtual environment"
 if [ -z "${VIRTUAL_ENV}" ] && [ -z "${CONDA_PREFIX}" ]; then
     echo 'No virtual environment detected: none of $VIRTUAL_ENV or $CONDA_PREFIX is set.'
-    echo "See https://lincc-ppt.readthedocs.io/ for details."
-    exit 1
+    echo
+    echo "=== This script is going to install the project in the system python environment ==="
+    echo "Proceed? [y/N]"
+    read -r RESPONCE
+    if [ "${RESPONCE}" != "y" ]; then
+        echo "See https://lincc-ppt.readthedocs.io/ for details."
+        echo "Exiting."
+        exit 1
+    fi
+
 fi
 
 echo "Checking pip version"

--- a/python-project-template/.prepare_project.sh
+++ b/python-project-template/.prepare_project.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
+echo "Checking virtual environment"
+if [ -z "${VIRTUAL_ENV}" ] && [ -z "${CONDA_PREFIX}" ]; then
+    echo 'No virtual environment detected: none of $VIRTUAL_ENV or $CONDA_PREFIX is set.'
+    echo "See https://lincc-ppt.readthedocs.io/ for details."
+    exit 1
+fi
+
 echo "Checking pip version"
 MINIMUM_PIP_VERSION=22
-pipversion=( $(pip --version | awk '{print $2}' | sed 's/\./ /g') )
+pipversion=( $(python -m pip --version | awk '{print $2}' | sed 's/\./ /g') )
 if let "${pipversion[0]}<${MINIMUM_PIP_VERSION}"; then
     echo "Insufficient version of pip found. Requires at least version ${MINIMUM_PIP_VERSION}."
     echo "See https://lincc-ppt.readthedocs.io/ for details."
@@ -25,10 +32,10 @@ echo "Initializing local git repository"
 } > /dev/null
 
 echo "Installing package and runtime dependencies in local environment"
-pip install -e . > /dev/null
+python -m pip install -e . > /dev/null
 
 echo "Installing developer dependencies in local environment"
-pip install -e .'[dev]' > /dev/null
+python -m pip install -e .'[dev]' > /dev/null
 
 echo "Installing pre-commit"
 pre-commit install > /dev/null


### PR DESCRIPTION
## Change Description

This PR should prevent user from installing stuff into their global Python paths. It does it in two ways:
1. Adds a note about this in both Readme and copier output
2. Checks if conda or venv is active in `.prepare_project.sh`. It also changes `pip` to `python -m pip` to be sure that pip from virtual environment is used, not the global one.

Fixes #399 


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests