### PR TITLE
Update default notification.

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -90,12 +90,11 @@ enforce_style:
 failure_notification:
     help: How would you like to receive workflow failure notifications?
     type: str
-    default: [email]
+    default: []
     multiselect: true
     choices:
         email (additional configuration required): email
         slack bot integration (additional configuration required): slack
-        none: none
     when: "{{ custom_install }}"
 
 mypy_type_checking:


### PR DESCRIPTION
## Change Description

Removes default selection of `email` for smoke test failure notifications. Also removes the "none" option, since you could potentially select [email, none], which doesn't make a lot of sense.

Closes #401 

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes unit / integration testing, or is small enough to be covered by existing tests