### PR TITLE
Update default answer for project_organization to meet regex requirements

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -36,7 +36,7 @@ package_name:
 project_organization:
     type: str
     help: What github organization will your project live under? 
-    default: my_organization
+    default: my-organization
     validator: >-
         {% if not (project_organization | regex_search('^[a-zA-Z0-9][a-zA-Z0-9\-]*$')) %}
         The name may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.


### PR DESCRIPTION
## Change Description
I updated the regex for the `project_organization` copier question, but didn't update the default answer to match. 🤦 This fixes the default answer so that it satisfies the regex.


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests