### PR TITLE
`.prepare_project.sh` -> `.initialize_new_project.sh` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd <path/to/destination>
 # Create a virtual environment, feel free to use conda, pyenv or your favorite tool
 python3 -mvenv ~/.virtualenvs/<env_name>
 source ~/.virtualenvs/<env_name>/bin/activate
-bash .prepare_project.sh
+bash .initialize_new_project.sh
 ```
 
 ## Contributing to the Template

--- a/copier.yml
+++ b/copier.yml
@@ -151,7 +151,7 @@ _message_after_copy: |
 
        $ cd {{ _copier_conf.dst_path }}
        $ python3 -mvenv ~/.virtualenvs/{{ project_name }} && source ~/.virtualenvs/{{ project_name }}/bin/activate
-       $ bash .prepare_project.sh
+       $ bash .initialize_new_project.sh
 
 ###
 # Below this line are Copier configuration options.

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -119,7 +119,7 @@ script in your new project directory.
 
 .. code-block:: bash
 
-    >> bash .prepare_project.sh
+    >> bash .initialize_new_project.sh
 
 This script will initialize your local git repository, install the new Python
 package in editable mode along with runtime and developer dependencies, and
@@ -131,7 +131,7 @@ initialize :doc:`pre-commit <../practices/precommit>`.
     to the pre-commit hooks checks. If they are not compliant the bash script will exit
     with a verbose error code. You should apply the suggestions and re-run the script.
 
-The full contents of the script can be seen on `Github <https://github.com/lincc-frameworks/python-project-template/tree/main/python-project-template/.prepare_project.sh>`_.
+The full contents of the script can be seen on `Github <https://github.com/lincc-frameworks/python-project-template/tree/main/python-project-template/.initialize_new_project.sh>`_.
 
 The script assumes that you have access to bash. If that is not true for your environment,
 you should be able to run all the commands manually in your environment using

--- a/python-project-template/.gitignore
+++ b/python-project-template/.gitignore
@@ -145,3 +145,6 @@ tmp/
 # Airspeed Velocity performance results
 _results/
 _html/
+
+# Project initialization script
+.initialize_new_project.sh

--- a/python-project-template/.initialize_new_project.sh
+++ b/python-project-template/.initialize_new_project.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+echo "Checking virtual environment"
+if [ -z "${VIRTUAL_ENV}" ] && [ -z "${CONDA_PREFIX}" ]; then
+    echo 'No virtual environment detected: none of $VIRTUAL_ENV or $CONDA_PREFIX is set.'
+    echo
+    echo "=== This script is going to install the project in the system python environment ==="
+    echo "Proceed? [y/N]"
+    read -r RESPONCE
+    if [ "${RESPONCE}" != "y" ]; then
+        echo "See https://lincc-ppt.readthedocs.io/ for details."
+        echo "Exiting."
+        exit 1
+    fi
+
+fi
+
+echo "Checking pip version"
+MINIMUM_PIP_VERSION=22
+pipversion=( $(python -m pip --version | awk '{print $2}' | sed 's/\./ /g') )
+if let "${pipversion[0]}<${MINIMUM_PIP_VERSION}"; then
+    echo "Insufficient version of pip found. Requires at least version ${MINIMUM_PIP_VERSION}."
+    echo "See https://lincc-ppt.readthedocs.io/ for details."
+    exit 1
+fi
+
+echo "Initializing local git repository"
+{
+    gitversion=( $(git version | git version | awk '{print $3}' | sed 's/\./ /g') )
+    if let "${gitversion[0]}<2"; then
+	# manipulate directly
+	git init . && echo 'ref: refs/heads/main' >.git/HEAD
+    elif let "${gitversion[0]}==2 & ${gitversion[1]}<34"; then
+	# rename master to main
+	git init . && { git branch -m master main 2>/dev/null || true; };
+    else
+	# set the initial branch name to main
+	git init --initial-branch=main >/dev/null
+    fi
+} > /dev/null
+
+echo "Installing package and runtime dependencies in local environment"
+python -m pip install -e . > /dev/null
+
+echo "Installing developer dependencies in local environment"
+python -m pip install -e .'[dev]' > /dev/null
+
+echo "Installing pre-commit"
+pre-commit install > /dev/null
+
+echo "Committing initial files"
+git add . && SKIP="no-commit-to-branch" git commit -m "Initial commit"

--- a/python-project-template/.setup_dev.sh
+++ b/python-project-template/.setup_dev.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script should be run by new developers to install this package in
+# editable mode and configure their local environment
+
 echo "Checking virtual environment"
 if [ -z "${VIRTUAL_ENV}" ] && [ -z "${CONDA_PREFIX}" ]; then
     echo 'No virtual environment detected: none of $VIRTUAL_ENV or $CONDA_PREFIX is set.'
@@ -24,21 +27,6 @@ if let "${pipversion[0]}<${MINIMUM_PIP_VERSION}"; then
     exit 1
 fi
 
-echo "Initializing local git repository"
-{
-    gitversion=( $(git version | git version | awk '{print $3}' | sed 's/\./ /g') )
-    if let "${gitversion[0]}<2"; then
-	# manipulate directly
-	git init . && echo 'ref: refs/heads/main' >.git/HEAD
-    elif let "${gitversion[0]}==2 & ${gitversion[1]}<34"; then
-	# rename master to main
-	git init . && { git branch -m master main 2>/dev/null || true; };
-    else
-	# set the initial branch name to main
-	git init --initial-branch=main >/dev/null
-    fi
-} > /dev/null
-
 echo "Installing package and runtime dependencies in local environment"
 python -m pip install -e . > /dev/null
 
@@ -48,5 +36,6 @@ python -m pip install -e .'[dev]' > /dev/null
 echo "Installing pre-commit"
 pre-commit install > /dev/null
 
-echo "Committing initial files"
-git add . && SKIP="no-commit-to-branch" git commit -m "Initial commit"
+#######################################################
+# Include any additional configurations below this line
+#######################################################


### PR DESCRIPTION
Changed name of .prepare_project.sh, added .initialize_new_project.sh script to .gitignore. Created a .setup_dev.sh script that is similar to the original prepare_project script, but excludes the various local git repo setup steps. 


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests