### PR TITLE
Updating URL in pre-copy message

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -5,7 +5,7 @@ _message_before_copy: |
     generate a tailored project for you.
 
     You can refer to our documentation for more details and contact info
-    https://lincc-ppt.readthedocs.io/en/latest/
+    https://lincc-ppt.readthedocs.io/en/latest/source/new_project.html#template-questions
 
 custom_install:
     help: Would you like to use simple (default tooling) or customized installation? 

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -9,15 +9,16 @@ Choose where you would like to create your new project, and call copier with
 the template.
 
 .. important::
-    A new version of Copier was released June 4, 2023. Please ensure that your
-    installed version of Copier >= 8.0.0. The following command will not work
-    with earlier versions of Copier.
+    This template is optimized to work well with Copier >= 9.1.0.
 
-    ``pipx list`` will display the currently installed version of Copier.
+    ``pipx list`` will display installed the currently install version of Copier.
 
 .. code-block:: bash
 
     >> copier copy gh:lincc-frameworks/python-project-template <new/project/directory>
+
+Template questions
+******************
 
 Copier will ask you questions for how to set up the project. These questions 
 will be used to fill in aspects of the project's configuration, including both 

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -11,7 +11,7 @@ the template.
 .. important::
     This template is optimized to work well with Copier >= 9.1.0.
 
-    ``pipx list`` will display installed the currently install version of Copier.
+    ``pipx list`` will display the currently installed version of Copier.
 
 .. code-block:: bash
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -62,14 +62,13 @@ It's really neat!
 Given that your system satisfies the requirements, go ahead and install Copier.
 
 .. important::
-    A new version of Copier was released June 4, 2023. Please ensure that your
-    installed version of Copier >= 8.0.0.
+    This template is optimized to work well with Copier >= 9.1.0.
 
     ``pipx list`` will display installed the currently install version of Copier.
 
 .. code-block:: bash
 
-    >> pipx install --force copier>8.0.0
+    >> pipx install --force copier>9.1.0
 
 Now choose your next adventure...
 -------------------------------------

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -64,7 +64,7 @@ Given that your system satisfies the requirements, go ahead and install Copier.
 .. important::
     This template is optimized to work well with Copier >= 9.1.0.
 
-    ``pipx list`` will display installed the currently install version of Copier.
+    ``pipx list`` will display the currently installed version of Copier.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Updating URL in pre-copy message. Added new subtitle to docs so that we link directly to the table.


## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests