### PR TITLE
Fix asv `show_commit_url`

### DIFF
--- a/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/asv.conf.json.jinja
+++ b/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/asv.conf.json.jinja
@@ -32,7 +32,7 @@
     // variable.
     "environment_type": "virtualenv",
     // the base URL to show a commit for the project.
-    "show_commit_url": "https://github.com/{{project_organization}}/{{project_name}}/commit",
+    "show_commit_url": "https://github.com/{{project_organization}}/{{project_name}}/commit/",
     // The Pythons you'd like to test against. If not provided, defaults
     // to the current version of Python used to run `asv`.
     "pythons": [


### PR DESCRIPTION
Adds a missing slash to the asv `show_commit_url`.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests