### PR TITLE
Revert @ main action versions

### DIFF
--- a/python-project-template/.github/workflows/code_style.yml.jinja
+++ b/python-project-template/.github/workflows/code_style.yml.jinja
@@ -21,9 +21,9 @@ jobs:
         python-version: {{ python_versions }}
 
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
     - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-      uses: actions/setup-python@main
+      uses: actions/setup-python@v5
       with:
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies

--- a/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
+++ b/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
@@ -13,11 +13,11 @@ jobs:
     env: 
       SKIP: "check-lincc-frameworks-template-version,pytest-check,no-commit-to-branch,validate-pyproject,check-added-large-files,sphinx-build"
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 
     - name: Set up Python
-      uses: actions/setup-python@main
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -26,8 +26,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - uses: pre-commit/action@main # Still using Node 16
+    - uses: pre-commit/action@v3
       with:
         extra_args: --from-ref {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %} --to-ref {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
-    - uses: pre-commit-ci/lite-action@main
+    - uses: pre-commit-ci/lite-action@v1
       if: always()

--- a/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
+++ b/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
@@ -26,8 +26,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - uses: pre-commit/action@v3
+    - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --from-ref {% raw %}${{ github.event.pull_request.base.sha }}{% endraw %} --to-ref {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
-    - uses: pre-commit-ci/lite-action@v1
+    - uses: pre-commit-ci/lite-action@v1.0.2
       if: always()

--- a/python-project-template/.github/workflows/publish-to-pypi.yml
+++ b/python-project-template/.github/workflows/publish-to-pypi.yml
@@ -22,9 +22,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@main
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/python-project-template/.github/workflows/smoke-test.yml.jinja
+++ b/python-project-template/.github/workflows/smoke-test.yml.jinja
@@ -23,9 +23,9 @@ jobs:
         python-version: {{ python_versions }}
 
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
     - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-      uses: actions/setup-python@main
+      uses: actions/setup-python@v5
       with:
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
 {%- if 'email' in failure_notification %}
     - name: Send status to author's email      
       if: {% raw %}${{ failure() }} && github.event_name != 'workflow_dispatch' }}{% endraw %} # Only email if the workflow failed and was not manually started. Customize this as necessary.
-      uses: dawidd6/action-send-mail@master
+      uses: dawidd6/action-send-mail@v3
       with:
         # Required mail server address if not connection_url:
         server_address: smtp.gmail.com
@@ -80,7 +80,7 @@ jobs:
     - name: Send status to Slack app
       if: ${{ failure() && github.event_name != 'workflow_dispatch' }} # Only post if the workflow failed and was not manually started. Customize this as necessary.
       id: slack
-      uses: slackapi/slack-github-action@main
+      uses: slackapi/slack-github-action@v1
       with:
         # For posting a rich message using Block Kit
         payload: | # The payload defined here can be customized to you liking https://api.slack.com/reference/block-kit/blocks 

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -18,9 +18,9 @@ jobs:
         python-version: {{ python_versions }}
 
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
     - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
-      uses: actions/setup-python@main
+      uses: actions/setup-python@v5
       with:
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
     - name: Install dependencies
@@ -33,6 +33,6 @@ jobs:
       run: |
         python -m pytest --cov={{package_name}} --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@main
+      uses: codecov/codecov-action@v4
       with:
         token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Cache Python ${{ env.PYTHON_VERSION }}
-        uses: actions/cache@main
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: python-${{ env.PYTHON_VERSION }}
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Checkout main branch of the repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache Python ${{ env.PYTHON_VERSION }}
-        uses: actions/cache@main
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: python-${{ env.PYTHON_VERSION }}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: Checkout main branch of the repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache Python ${{ env.PYTHON_VERSION }}
-        uses: actions/cache@main
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: python-${{ env.PYTHON_VERSION }}
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -71,7 +71,7 @@ jobs:
           echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Use last nightly commit hash from cache
-        uses: actions/cache@main
+        uses: actions/cache@v4
         with:
           path: ${{ env.WORKING_DIR }}
           key: nightly-results-${{ steps.nightly-dates.outputs.yesterday }}
@@ -88,7 +88,7 @@ jobs:
           echo $CURRENT_HASH > $HASH_FILE
 
       - name: Update last nightly hash in cache
-        uses: actions/cache@main
+        uses: actions/cache@v4
         with:
           path: ${{ env.WORKING_DIR }}
           key: nightly-results-${{ steps.nightly-dates.outputs.today }}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Cache Python ${{ env.PYTHON_VERSION }}
-      uses: actions/cache@main
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: python-${{ env.PYTHON_VERSION }}
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@main
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
   asv-pr:
@@ -41,14 +41,14 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
     steps:
     - name: Checkout PR branch of the repository
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Display Workflow Run Information
       run: |
         echo "Workflow Run ID: ${{ github.run_id }}"
     - name: Cache Python ${{ env.PYTHON_VERSION }}
-      uses: actions/cache@main
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: python-${{ env.PYTHON_VERSION }}
@@ -62,7 +62,7 @@ jobs:
     - name: Save pull request number
       run: echo ${{ github.event.pull_request.number }} > ${{ env.ARTIFACTS_DIR }}/pr
     - name: Get current job logs URL
-      uses: Tiryoh/gha-jobid-action@main
+      uses: Tiryoh/gha-jobid-action@v1
       id: jobs
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
       env:
         STEP_URL: "${{ steps.jobs.outputs.html_url }}#step:11:1"
     - name: Upload artifacts (PR number and benchmarks output)
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: benchmark-artifacts
         path: ${{ env.ARTIFACTS_DIR }}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
@@ -28,7 +28,7 @@ jobs:
         echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
         echo "Event: ${{ github.event.workflow_run.event }}"
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@master
+      uses: dawidd6/action-download-artifact@v3
       with:
         name: benchmark-artifacts
         run_id: ${{ github.event.workflow_run.id }}
@@ -39,14 +39,14 @@ jobs:
         printf "Output:\n$(cat output)"
         printf "pr=$(cat pr)" >> $GITHUB_OUTPUT
     - name: Find benchmarks comment
-      uses: peter-evans/find-comment@main
+      uses: peter-evans/find-comment@v3
       id: find-comment
       with:
         issue-number: ${{ steps.pr-info.outputs.pr }}
         comment-author: 'github-actions[bot]'
         body-includes: view all benchmarks
     - name: Create or update benchmarks comment
-      uses: peter-evans/create-or-update-comment@main
+      uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         issue-number: ${{ steps.pr-info.outputs.pr }}

--- a/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_docs %}build-documentation.yml{% endif %}.jinja
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@main
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies


### PR DESCRIPTION
Reverts usage of @ main action versions in favor of dependabot's dependency management. Closes #412. 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests