### PR TITLE
Add validation of Github workflows to pre-commit

### DIFF
--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -37,6 +37,12 @@ repos:
       - id: validate-pyproject
         name: Validate pyproject.toml
         description: Verify that pyproject.toml adheres to the established schema.
+    # Verify that GitHub workflows are well formed
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.0
+    hooks:
+      - id: check-github-workflows
+        args: ["--verbose"]
 {%- if 'isort' in enforce_style %}
     # Automatically sort the imports used in .py files
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
This pull request adds a new hook to the `pre-commit` config to validate GitHub workflows. It downloads the schema directly from the GitHub vendor (which is updated periodically) and checks if the schema is compliant. Closes #383.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests