### PR TITLE
Do not use ruff linter on Jupyter notebooks

### DIFF
--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -100,7 +100,7 @@ repos:
     hooks:
       - id: ruff
         name: Lint code using ruff; sort and organize imports 
-        types_or: [ python, pyi, jupyter ]
+        types_or: [ python, pyi ]
         args: ["--fix"]
 {%- endif %}
 {%- if 'ruff_format' in enforce_style %}


### PR DESCRIPTION
Running ruff linter on Jupyter notebooks is too strict. Removing it for now. Closes #389.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests