### PR TITLE
Add copybutton extension to template docs.

### DIFF
--- a/python-project-template/{% if include_docs %}docs{% endif %}/conf.py.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/conf.py.jinja
@@ -31,6 +31,16 @@ extensions.append("autoapi.extension")
 extensions.append("nbsphinx")
 {%- endif %}
 
+# -- sphinx-copybutton configuration ----------------------------------------
+extensions.append("sphinx_copybutton")
+## sets up the expected prompt text from console blocks, and excludes it from
+## the text that goes into the clipboard.
+copybutton_exclude = '.linenos, .gp'
+copybutton_prompt_text = ">> "
+
+## lets us suppress the copy button on select code blocks.
+copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
+
 templates_path = []
 exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 

--- a/python-project-template/{% if include_docs %}docs{% endif %}/conf.py.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/conf.py.jinja
@@ -35,7 +35,7 @@ extensions.append("nbsphinx")
 extensions.append("sphinx_copybutton")
 ## sets up the expected prompt text from console blocks, and excludes it from
 ## the text that goes into the clipboard.
-copybutton_exclude = '.linenos, .gp'
+copybutton_exclude = ".linenos, .gp"
 copybutton_prompt_text = ">> "
 
 ## lets us suppress the copy button on select code blocks.

--- a/python-project-template/{% if include_docs %}docs{% endif %}/index.rst.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/index.rst.jinja
@@ -13,7 +13,7 @@ virtual environment. LINCC-Frameworks engineers primarily use `conda` to manage 
 environments. If you have conda installed locally, you can run the following to
 create and activate a new environment.
 
-.. code-block:: bash
+.. code-block:: console
 
    >> conda create env -n <env_name> python=3.10
    >> conda activate <env_name>
@@ -22,7 +22,7 @@ create and activate a new environment.
 Once you have created a new environment, you can install this project for local
 development using the following commands:
 
-.. code-block:: bash
+.. code-block:: console
 
    >> pip install -e .'[dev]'
    >> pre-commit install

--- a/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
@@ -1,6 +1,7 @@
 sphinx
 sphinx-rtd-theme
 sphinx-autoapi
+sphinx-copybutton
 {%- if include_notebooks %}
 nbsphinx
 ipython


### PR DESCRIPTION
## Change Description

Adds sphinx-copybutton extension by default for new projects from the template. sphinx-copybutton is my real Valentine this year.

Closes #424 

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests