### PR TITLE
Install sphinx from docs/requirements.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ extensions = ["sphinx_copybutton", "sphinx.ext.autosectionlabel"]
 # -- sphinx-copybutton configuration ----------------------------------------
 ## sets up the expected prompt text from console blocks, and excludes it from
 ## the text that goes into the clipboard.
-copybutton_exclude = '.linenos, .gp'
+copybutton_exclude = ".linenos, .gp"
 copybutton_prompt_text = ">> "
 
 ## lets us suppress the copy button on select code blocks.
@@ -40,7 +40,7 @@ copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
 
 # -- Options for autosectionlabel -------------------------------------------------
 
-autosectionlabel_prefix_document=True
+autosectionlabel_prefix_document = True
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/python-project-template/.initialize_new_project.sh
+++ b/python-project-template/.initialize_new_project.sh
@@ -44,6 +44,7 @@ python -m pip install -e . > /dev/null
 
 echo "Installing developer dependencies in local environment"
 python -m pip install -e .'[dev]' > /dev/null
+if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
 
 echo "Installing pre-commit"
 pre-commit install > /dev/null

--- a/python-project-template/.setup_dev.sh
+++ b/python-project-template/.setup_dev.sh
@@ -32,6 +32,7 @@ python -m pip install -e . > /dev/null
 
 echo "Installing developer dependencies in local environment"
 python -m pip install -e .'[dev]' > /dev/null
+if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
 
 echo "Installing pre-commit"
 pre-commit install > /dev/null

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -20,9 +20,6 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">={{ python_versions[0] }}"
 dependencies = [
-{%- if include_notebooks %}
-    "ipykernel", # Support for Jupyter notebooks
-{%- endif %}
 ]
 
 [project.urls]
@@ -31,36 +28,23 @@ dependencies = [
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "pytest-cov", # Used to report total code coverage
-    "pre-commit", # Used to run checks before finalizing a git commit
-{%- if include_docs %}
-    "sphinx", # Used to automatically generate documentation
-    "sphinx-rtd-theme", # Used to render documentation
-    "sphinx-autoapi", # Used to automatically generate api documentation
-{%- endif %}
-{%- if 'pylint' in enforce_style %}
-    "pylint", # Used for static linting of files
+{%- if include_benchmarks %}
+    "asv==0.6.1", # Used to compute performance benchmarks
 {%- endif %}
 {%- if 'black'  in enforce_style %}
     "black", # Used for static linting of files
 {%- endif %}
-{%- if 'ruff_lint' in enforce_style or 'ruff_format' in enforce_style %}
-    "ruff", # Used for static linting of files
-{%- endif %}
 {%- if mypy_type_checking != 'none' %}
     "mypy", # Used for static type checking of files
 {%- endif %}
-{%- if include_notebooks %}
-    # if you add dependencies here while experimenting in a notebook and you
-    # want that notebook to render in your documentation, please add the
-    # dependencies to ./docs/requirements.txt as well.
-    "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
-    "nbsphinx", # Used to integrate Python notebooks into Sphinx documentation
-    "ipython", # Also used in building notebooks into Sphinx
+    "pre-commit", # Used to run checks before finalizing a git commit
+{%- if 'pylint' in enforce_style %}
+    "pylint", # Used for static linting of files
 {%- endif %}
-{%- if include_benchmarks %}
-    "asv==0.6.1", # Used to compute performance benchmarks
+    "pytest",
+    "pytest-cov", # Used to report total code coverage
+{%- if 'ruff_lint' in enforce_style or 'ruff_format' in enforce_style %}
+    "ruff", # Used for static linting of files
 {%- endif %}
 ]
 

--- a/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
@@ -1,10 +1,12 @@
+{%- if include_notebooks %}
+ipykernel
+ipython
+jupyter
+jupytext
+nbconvert
+nbsphinx
+{%- endif %}
 sphinx
-sphinx-rtd-theme
 sphinx-autoapi
 sphinx-copybutton
-{%- if include_notebooks %}
-nbsphinx
-ipython
-jupytext
-jupyter
-{%- endif %}
+sphinx-rtd-theme


### PR DESCRIPTION
## Change Description

Closes #431 .

Adds lines in setup scripts to install all dependencies in docs/requirements, so we're not maintaining the list of docs requirements in two places. Removes those dependencies from pyproject.toml, and also alpha-sorts the current dependencies list (because it irks me that a freshly-minted project is unsorted).

## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests