### PR TITLE
Move jupyter requirement.

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -34,6 +34,7 @@ dev = [
 {%- if 'black'  in enforce_style %}
     "black", # Used for static linting of files
 {%- endif %}
+    "jupyter", # Clears output from Jupyter notebooks
 {%- if mypy_type_checking != 'none' %}
     "mypy", # Used for static type checking of files
 {%- endif %}

--- a/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
@@ -1,7 +1,6 @@
 {%- if include_notebooks %}
 ipykernel
 ipython
-jupyter
 jupytext
 nbconvert
 nbsphinx


### PR DESCRIPTION
## Change Description

Closes #440. Moves `jupyter` dependency back to `.dev`.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests