### PR TITLE
Force earlier version of pyyaml-include

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "sphinx", # Used to automatically generate documentation
     "sphinx-rtd-theme", # Used to render documentation
     "sphinx-copybutton",
+    "pyyaml-include<2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Change Description

Closes #445 

`pyyaml-include` is a transitive dependency, included from copier. A recent version introduced breaking changes in copier.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests