### PR TITLE
Template: numpy v2.0 lint for ruff

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -104,7 +104,8 @@ select = [
     "D300",
     "D417",
     "D419",
-
+    # Numpy v2.0 compatibility
+    "NPY201",
 ]
 
 ignore = [


### PR DESCRIPTION
## Change Description

Add "NPY201" ruff lint as recommended by Numpy 2.0 migration guide 
https://numpy.org/devdocs/numpy_2_0_migration_guide.html 

## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests