### PR TITLE
Changing README.md to use conda create

### DIFF
--- a/python-project-template/README.md.jinja
+++ b/python-project-template/README.md.jinja
@@ -29,7 +29,7 @@ environments. If you have conda installed locally, you can run the following to
 create and activate a new environment.
 
 ```
->> conda create env -n <env_name> python=3.10
+>> conda create -n <env_name> python=3.10
 >> conda activate <env_name>
 ```
 


### PR DESCRIPTION
## Change Description

Changing README.md to use `conda create` over `conda create env` the latter is an error on current versions of mamba

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests