### PR TITLE
Adding a couple of README breadcrumbs for new users

### DIFF
--- a/python-project-template/.github/README.md
+++ b/python-project-template/.github/README.md
@@ -1,0 +1,23 @@
+# The .github directory
+
+This directory contains various configurations and .yml files that are used to
+define GitHub actions and behaviors.
+
+## Workflows
+
+The .yml files in ``./workflows`` are used to define the various continuous 
+integration scripts that will be run on your behalf e.g. nightly as a smoke check,
+or when you create a new PR.
+
+For more information about CI and workflows, look here: https://lincc-ppt.readthedocs.io/en/latest/practices/ci.html
+
+## Configurations
+
+Templates for various different issue types are defined in ``./ISSUE_TEMPLATE``
+and a pull request template is defined as ``pull_request_template.md``. Adding,
+removing, and modifying these templates to suit the needs of your project is encouraged.
+
+For more information about these templates, look here: https://lincc-ppt.readthedocs.io/en/latest/practices/issue_pr_templating.html
+
+
+Or if you still have questions contact us: https://lincc-ppt.readthedocs.io/en/latest/source/contact.html

--- a/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/README.md
+++ b/python-project-template/{% if include_benchmarks %}benchmarks{% endif %}/README.md
@@ -1,0 +1,12 @@
+# Benchmarks
+
+This directory contains files that will be run via continuous testing either
+nightly or after committing code to a pull request. 
+
+The runtime and/or memory usage of the functions defined in these files will be
+tracked and reported to give you a sense of the overall performance of your code.
+
+You are encouraged to add, update, or remove benchmark functions to suit the needs
+of your project.
+
+For more information, see the documentation here: https://lincc-ppt.readthedocs.io/en/latest/practices/ci_benchmarking.html

--- a/python-project-template/{% if include_docs %}docs{% endif %}/notebooks/README.md
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/notebooks/README.md
@@ -10,4 +10,13 @@ This means they should be able to be run with the resources in the repo, and in 
 
 This is great for notebooks that can run in a few minutes, on smaller datasets.
 
+If you would like to include these notebooks in automatically generated documentation
+simply add the notebook name to the ``../notebooks.rst`` file. Be aware that you may
+also need to update the ``../requirements.txt`` file if your notebooks have
+dependencies that are not specified in ``../pyproject.toml``.
+
 For notebooks that require large datasets, access to third party APIs, large CPU or GPU requirements, put them in `./pre_executed` instead.
+
+For more information look here: https://lincc-ppt.readthedocs.io/en/latest/practices/sphinx.html#python-notebooks
+
+Or if you still have questions contact us: https://lincc-ppt.readthedocs.io/en/latest/source/contact.html

--- a/python-project-template/{% if include_docs %}docs{% endif %}/notebooks/README.md
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/notebooks/README.md
@@ -11,9 +11,12 @@ This means they should be able to be run with the resources in the repo, and in 
 This is great for notebooks that can run in a few minutes, on smaller datasets.
 
 If you would like to include these notebooks in automatically generated documentation
-simply add the notebook name to the ``../notebooks.rst`` file. Be aware that you may
-also need to update the ``../requirements.txt`` file if your notebooks have
-dependencies that are not specified in ``../pyproject.toml``.
+simply add the notebook name to the ``../notebooks.rst`` file, and include a markdown
+cell at the beginning of your notebook with ``# Title`` that will be used as the text
+in the table of contents in the documentation.
+
+Be aware that you may also need to update the ``../requirements.txt`` file if
+your notebooks have dependencies that are not specified in ``../pyproject.toml``.
 
 For notebooks that require large datasets, access to third party APIs, large CPU or GPU requirements, put them in `./pre_executed` instead.
 


### PR DESCRIPTION
Adding README breadcrumbs in a couple of places. *Not* adding to ./src or ./tests at this point, as those seem like they should be intuitive enough - plus I don't think we have substantial documentation about adding source code or unit tests. 