### PR TITLE
Add type hints to benchmarks

### DIFF
--- a/python-project-template/src/{{package_name}}/{% if include_benchmarks %}example_benchmarks.py{% endif %}
+++ b/python-project-template/src/{{package_name}}/{% if include_benchmarks %}example_benchmarks.py{% endif %}
@@ -4,11 +4,11 @@ import random
 import time
 
 
-def runtime_computation():
+def runtime_computation() -> None:
     """Runtime computation consuming between 0 and 5 seconds."""
     time.sleep(random.uniform(0, 5))
 
 
-def memory_computation():
+def memory_computation() -> list[int]:
     """Memory computation for a random list up to 512 samples."""
     return [0] * random.randint(0, 512)


### PR DESCRIPTION
## Change Description

Adds type hints to the `example_benchmarks` file. Fixes #457 


## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests