### PR TITLE
Adding 3.13 and removing 3.7 from available python versions.

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -68,12 +68,12 @@ python_versions:
     type: str
     multiselect: true
     choices:
-        "3.7 (end-of-life)": "3.7"
-        "3.8": "3.8"
+        "3.8 (end-of-life)": "3.8"
         "3.9": "3.9"
         "3.10": "3.10"
         "3.11": "3.11"
         "3.12": "3.12"
+        "3.13": "3.13"
     when: "{{ custom_install }}"
 
 enforce_style:


### PR DESCRIPTION
Python 3.13 was recently released, 3.7 has been past end of life for 1 year. 

https://devguide.python.org/versions/