### PR TITLE
Updating "clear jupyter notebook" pre-commit hook "stage" value from `commit` to `pre-commit`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "black", # Used to format code
     "pre-commit", # Used to run checks prior to committing code
     "pytest", # Used to run tests
+    "pytest-cov", # Used to measure test coverage
     "pylint", # test pylint in unit tests
     "pytest-copie", # Used to create hydrated copier projects for testing
     "tox", # Used to run tests in multiple environments

--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -18,7 +18,7 @@ repos:
         description: Clear output from Jupyter notebooks.
         files: \.ipynb$
         exclude: ^docs/pre_executed
-        stages: [commit]
+        stages: [pre-commit]
         language: system
         entry: jupyter nbconvert --clear-output
     # Prevents committing directly branches named 'main' and 'master'.


### PR DESCRIPTION
In pre-commit version 3.2, the accepted values for "stage" changed to match the various pre-commit hooks. 

This is outlined in the documentation here https://pre-commit.com/#confining-hooks-to-run-at-certain-stages
Specifically this line: 

> new in 3.2.0: The values of stages match the hook names. Previously, commit, push, and merge-commit matched pre-commit, pre-push, and pre-merge-commit respectively.