### PR TITLE
Change git remote paths from HTTPS to SSH

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -156,7 +156,7 @@ _message_after_copy: |
        $ bash .initialize_new_project.sh
 
     Push your project to a new repository on GitHub:
-       $ git remote add origin https://github.com/{{project_organization}}/{{project_name}}.git
+       $ git remote add origin git@github.com:{{project_organization}}/{{project_name}}.git
        $ git push -u origin main
 
     {%- if include_notebooks %}

--- a/docs/source/new_project.rst
+++ b/docs/source/new_project.rst
@@ -45,7 +45,7 @@ questions:
    * - *What github organization will your project live under?*
      - This will either be a github organization, or your github username, if you're working outside 
        of an organization. This is used to construct URLs to your project, like
-       ``https://github.com/{{project_organization}}/{{project_name}}``
+       ``git@github.com:{{project_organization}}/{{project_name}}``
    * - *What is the name of the code author?* 
      - The name of the code's author, or the organization that is responsible for the code.
        This will be used in the project and documentation metadata. 

--- a/docs/source/template_options.rst
+++ b/docs/source/template_options.rst
@@ -25,7 +25,7 @@ The name of your project.
 
 Must start with a lowercase letter, followed by one or more of the following (a-z, 0-9, _, -).
 
-This will be used to connect to your project on github, as in ``https://github.com/{{project_organization}}/{{project_name}}``.
+This will be used to connect to your project on github, as in ``git@github.com:{{project_organization}}/{{project_name}}``.
 
 If you distribute your code via PyPI, this is the name that will be used. This will allow users to install like so: ``pip install <project_name>``.
 
@@ -71,7 +71,7 @@ This will be:
 
     * Your GitHub username, if you're working outside of an organization. 
 
-This is used to construct URLs to your project, as in: ``https://github.com/{{project_organization}}/{{project_name}}``.
+This is used to construct URLs to your project, as in: ``git@github.com:{{project_organization}}/{{project_name}}``.
 
 
 5. Name of the code author


### PR DESCRIPTION
## Change Description

Usually, SSH git URLs are used for remotes when working from the terminal. This PR proposes to change the suggested `git remote add` command to use SSH paths instead of HTTPS paths.

However, I'm not sure about other use cases: GUI clients, VS Code, etc.

## Checklist

- [ ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests