### PR TITLE
Propagate dependabot changes from last couple months.

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -44,6 +44,8 @@ jobs:
       id: slack
       uses: slackapi/slack-github-action@v2
       with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: webhook-trigger
         payload: |
           {
             "blocks": [
@@ -73,6 +75,3 @@ jobs:
               }
             ]
           }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
+++ b/python-project-template/.github/workflows/pre-commit-ci.yml.jinja
@@ -32,5 +32,5 @@ jobs:
         extra_args: --all-files --verbose
       env:
         SKIP: "check-lincc-frameworks-template-version,no-commit-to-branch,check-added-large-files,validate-pyproject,sphinx-build,pytest-check"
-    - uses: pre-commit-ci/lite-action@v1.0.2
+    - uses: pre-commit-ci/lite-action@v1.1.0
       if: failure() && github.event_name == 'pull_request' && github.event.pull_request.draft == false

--- a/python-project-template/.github/workflows/smoke-test.yml.jinja
+++ b/python-project-template/.github/workflows/smoke-test.yml.jinja
@@ -80,9 +80,11 @@ jobs:
     - name: Send status to Slack app
       if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
       id: slack
-      uses: slackapi/slack-github-action@v1
+      uses: slackapi/slack-github-action@v2
       with:
         # For posting a rich message using Block Kit
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: webhook-trigger
         payload: |
           {
             "blocks": [
@@ -112,8 +114,5 @@ jobs:
               }
             ]
           }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     {%- endraw %}
 {%- endif %}

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -33,6 +33,6 @@ jobs:
       run: |
         python -m pytest --cov={{package_name}} --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}publish-benchmarks-pr.yml{% endif %}.jinja
@@ -28,7 +28,7 @@ jobs:
         echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
         echo "Event: ${{ github.event.workflow_run.event }}"
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@v3
+      uses: dawidd6/action-download-artifact@v7
       with:
         name: benchmark-artifacts
         run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Change Description

The slack-github-action v1->v2 update had several breaking changes to the way that webhooks are called from the github action. This fixes the action in THIS repo, and for templated repos. 

https://github.com/slackapi/slack-github-action/releases

This also sneaks in a few updates from dependabot to other actions from the last few months.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests