### PR TITLE
Upload social media preview; add banner image to top of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+![Banner Image for LINCC Frameworks Python Project Template](https://github.com/user-attachments/assets/8977125e-b4c7-4f12-8f63-f3feb70a3ac6)
 # LINCC Frameworks Python Project Template
+
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/lincc-frameworks/python-project-template)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/lincc-frameworks/python-project-template/ci.yml)](https://github.com/lincc-frameworks/python-project-template/ci.yml)
 [![Read the Docs](https://img.shields.io/readthedocs/lincc-ppt)](https://lincc-ppt.readthedocs.io/)


### PR DESCRIPTION
## Change Description
Closes #463 

Two changes were discussed in this issue:
1. Made a social media preview (can see [on the settings page](https://github.com/lincc-frameworks/python-project-template/settings))
2. Made a banner for the top of the README

## An aside
Found a cool [GitHub Social Image Generator ](https://www.bannerbear.com/demos/github-social-preview-generator-tool/#try_a_git) while exploring, but it doesn't let you use your own images. If anyone's waiting for a run to finish or needs to kill a few minutes sometime, though, could be nice to generate them for our other repos.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [x] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests