### PR TITLE
Exclude _build directory from pre-commit sphinx build.

### DIFF
--- a/python-project-template/.pre-commit-config.yaml.jinja
+++ b/python-project-template/.pre-commit-config.yaml.jinja
@@ -164,7 +164,7 @@ repos:
             "-d", # Flag for cached environment and doctrees
             "./docs/_build/doctrees", # Directory
             "-D", # Flag to override settings in conf.py
-            "exclude_patterns=notebooks/*", # Exclude our notebooks from pre-commit
+            "exclude_patterns=notebooks/*,_build", # Exclude notebooks and build dir from pre-commit
           ]
 {%- elif include_docs %}
     # Make sure Sphinx can build the documentation without issues.


### PR DESCRIPTION
## Change Description
Include `_build` in the list of excluded patterns when sphinx is building documentation during pre-commit. FWIW, the makefile for building docs from the command line also lists `_build` as a directory to exclude.