### PR TITLE
Fixing .setup_dev.sh to only log on errors.

### DIFF
--- a/python-project-template/.setup_dev.sh
+++ b/python-project-template/.setup_dev.sh
@@ -32,7 +32,7 @@ python -m pip install -e . > /dev/null
 
 echo "Installing developer dependencies in local environment"
 python -m pip install -e .'[dev]' > /dev/null
-if [ -f docs/requirements.txt ]; then python -m pip install -r docs/requirements.txt; fi
+if [ -f docs/requirements.txt ]; then python -m pip install -r docs/requirements.txt > /dev/null; fi
 
 echo "Installing pre-commit"
 pre-commit install > /dev/null


### PR DESCRIPTION
## Change Description

Consistently swallow log-scroll when running pip in .setup_dev.sh

## Checklist

- [X ] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [ X] This change includes integration testing, or is small enough to be covered by existing tests