### PR TITLE
Only style configurations only when selected

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -78,11 +78,12 @@ target-version = ["py{{ py.min(python_versions) | replace(".", "") }}"]
 profile = "black"
 line_length = 110
 {% endif -%}
-
+{% if 'ruff_lint' in enforce_style or 'ruff_format' in enforce_style -%}
 [tool.ruff]
 line-length = 110
 target-version = "py{{ py.min(python_versions) | replace(".", "") }}"
-
+{% endif -%}
+{% if 'ruff_lint' in enforce_style -%}
 [tool.ruff.lint]
 select = [
     # pycodestyle
@@ -114,7 +115,6 @@ select = [
     # Numpy v2.0 compatibility
     "NPY201",
 ]
-
 ignore = [
     "UP006", # Allow non standard library generics in type hints
     "UP007", # Allow Union in type hints
@@ -124,6 +124,7 @@ ignore = [
     "UP015", # Allow redundant open parameters
     "UP028", # Allow yield in for loop
 ]
+{% endif -%}
 
 {%- if mypy_type_checking != 'none' %}
 [tool.setuptools.package-data]

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -68,13 +68,16 @@ testpaths = [
 ]
 addopts = "--doctest-modules --doctest-glob=*.rst"
 
+{% if 'black' in enforce_style -%}
 [tool.black]
 line-length = 110
-target-version = ["py{{ py.min(python_versions) | replace(".", "") }}"]
-
+target-version = 2
+{% endif -%}
+{% if 'isort' in enforce_style -%}
 [tool.isort]
 profile = "black"
 line_length = 110
+{% endif -%}
 
 [tool.ruff]
 line-length = 110

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -71,7 +71,7 @@ addopts = "--doctest-modules --doctest-glob=*.rst"
 {% if 'black' in enforce_style -%}
 [tool.black]
 line-length = 110
-target-version = 2
+target-version = ["py{{ py.min(python_versions) | replace(".", "") }}"]
 {% endif -%}
 {% if 'isort' in enforce_style -%}
 [tool.isort]


### PR DESCRIPTION
Only add isort and black configurations to `pyproject.toml` when they are selected. Closes #453. 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests