### PR TITLE
Pin virtualenv for asv

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -38,7 +38,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install dependencies
-      run: pip install "asv[virtualenv]==${{env.ASV_VERSION}}"
+      run: |
+        pip install asv==${{env.ASV_VERSION}}
+        pip install virtualenv==20.30 # Temporary fix to airspeed-velocity/asv#1484
     - name: Configure git
       run: |
         git config user.name "github-actions[bot]"

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
@@ -34,7 +34,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install dependencies
-      run: pip install "asv[virtualenv]==${{env.ASV_VERSION}}"
+      run: |
+        pip install asv==${{env.ASV_VERSION}}
+        pip install virtualenv==20.30 # Temporary fix to airspeed-velocity/asv#1484
     - name: Configure git
       run: |
         git config user.name "github-actions[bot]"

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -43,7 +43,9 @@ jobs:
       run: |
         echo "Workflow Run ID: ${{github.run_id}}"
     - name: Install dependencies
-      run: pip install "asv[virtualenv]==${{env.ASV_VERSION}}" lf-asv-formatter
+      run: |
+        pip install asv==${{env.ASV_VERSION}} lf-asv-formatter
+        pip install virtualenv==20.30 # Temporary fix to airspeed-velocity/asv#1484
     - name: Make artifacts directory
       run: mkdir -p ${{env.ARTIFACTS_DIR}}
     - name: Save pull request number

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -31,6 +31,7 @@ dependencies = [
 dev = [
 {%- if include_benchmarks %}
     "asv==0.6.4", # Used to compute performance benchmarks
+    "virtualenv==20.30", # Temporary fix to airspeed-velocity/asv#1484
 {%- endif %}
 {%- if 'black'  in enforce_style %}
     "black", # Used for static linting of files


### PR DESCRIPTION
The workflows for ASV benchmarks have been failing due to https://github.com/airspeed-velocity/asv/issues/1484. This PR pins virtualenv to v20.30 to fix those failures while a patch isn't released. I will file a ticket to remove this pin.

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [X] This change includes integration testing, or is small enough to be covered by existing tests