### PR TITLE
Disable test lowest version of dependencies by default.

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -147,7 +147,7 @@ include_benchmarks:
 
 test_lowest_version:
     help: Run pull request tests with the lowest versions of python and dependencies? Recommended if you are developing a library
-    default: direct
+    default: none
     choices:
         Do not test with lowest versions of dependencies: none
         Test with lowest versions of direct dependencies only (those listed in pyproject.toml): direct

--- a/docs/source/template_options.rst
+++ b/docs/source/template_options.rst
@@ -278,15 +278,15 @@ Read more at :doc:`../practices/ci_benchmarking`.
 16. Test against lowest versions
 ------------------------------------------------
 
-   +------------+-----------------------------------------------------------+
-   | Question   | Run pull request tests with the lowest versions of python |
-   |            | and dependencies?                                         |
-   +------------+-----------------------------------------------------------+
-   | Options    | | (none) Do not test with lowest versions of dependencies | 
-   |            | | **(direct)** Test with lowest versions of direct        |
-   |            |   dependencies only (those listed in pyproject.toml)      | 
-   |            | | (all) Test with lowest versions of all dependencies     |
-   +------------+-----------------------------------------------------------+
+   +------------+---------------------------------------------------------------+
+   | Question   | Run pull request tests with the lowest versions of python     |
+   |            | and dependencies?                                             |
+   +------------+---------------------------------------------------------------+
+   | Options    | | **(none)** Do not test with lowest versions of dependencies |
+   |            | | (direct) Test with lowest versions of direct                |
+   |            |   dependencies only (those listed in pyproject.toml)          |
+   |            | | (all) Test with lowest versions of all dependencies         |
+   +------------+---------------------------------------------------------------+
 
 Adds an optional stage to the end of the testing and coverage github CI workflow
 using the oldest version of python you've selected above, and will determine 


### PR DESCRIPTION
## Change Description
When originally implemented, testing the lowest version was enabled by default. This is great when someone is working through all the copier questions with a custom installation.

But when using a standard install, this is likely a surprising feature, so we'll disable it by default as a way to minimize the surprises for users.
