### PR TITLE
Syntax error if using "direct" testing of lowest dependencies.

### DIFF
--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -57,6 +57,7 @@ jobs:
           uv pip compile --resolution=lowest-direct pyproject.toml requirements.txt -o requirements_lowest.txt
         else
           uv pip compile --resolution=lowest-direct pyproject.toml -o requirements_lowest.txt
+        fi
         {%- elif test_lowest_version == 'all' %}
         if [ -f requirements.txt ]; then
           uv pip compile --resolution=lowest pyproject.toml requirements.txt -o requirements_lowest.txt


### PR DESCRIPTION
## Change Description

Missing the ending `fi` in testing lowest dependencies, with "direct" option.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests