### PR TITLE
Bump asv and unpin virtualenv

### DIFF
--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-main.yml{% endif %}.jinja
@@ -13,7 +13,7 @@ env:
 {%- import 'python-versions.jinja' as py%}
   PYTHON_VERSION: "{{ py.pref(python_versions) }}"
 {%- raw %}
-  ASV_VERSION: "0.6.4"
+  ASV_VERSION: "0.6.5"
   WORKING_DIR: ${{github.workspace}}/benchmarks
 
 concurrency:
@@ -38,9 +38,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install dependencies
-      run: |
-        pip install asv==${{env.ASV_VERSION}}
-        pip install virtualenv==20.30 # Temporary fix to airspeed-velocity/asv#1484
+      run: pip install asv[virtualenv]==${{env.ASV_VERSION}}
     - name: Configure git
       run: |
         git config user.name "github-actions[bot]"

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-nightly.yml{% endif %}.jinja
@@ -14,7 +14,7 @@ env:
 {%- import 'python-versions.jinja' as py%}
   PYTHON_VERSION: "{{ py.pref(python_versions) }}"
 {%- raw %}
-  ASV_VERSION: "0.6.4"
+  ASV_VERSION: "0.6.5"
   WORKING_DIR: ${{github.workspace}}/benchmarks
   NIGHTLY_HASH_FILE: nightly-hash
 
@@ -34,9 +34,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install dependencies
-      run: |
-        pip install asv==${{env.ASV_VERSION}}
-        pip install virtualenv==20.30 # Temporary fix to airspeed-velocity/asv#1484
+      run: pip install asv[virtualenv]==${{env.ASV_VERSION}}
     - name: Configure git
       run: |
         git config user.name "github-actions[bot]"

--- a/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
+++ b/python-project-template/.github/workflows/{% if include_benchmarks %}asv-pr.yml{% endif %}.jinja
@@ -20,7 +20,7 @@ env:
 {%- import 'python-versions.jinja' as py%}
   PYTHON_VERSION: "{{ py.pref(python_versions) }}"
 {%- raw %}
-  ASV_VERSION: "0.6.4"
+  ASV_VERSION: "0.6.5"
   WORKING_DIR: ${{github.workspace}}/benchmarks
   ARTIFACTS_DIR: ${{github.workspace}}/artifacts
 
@@ -43,9 +43,7 @@ jobs:
       run: |
         echo "Workflow Run ID: ${{github.run_id}}"
     - name: Install dependencies
-      run: |
-        pip install asv==${{env.ASV_VERSION}} lf-asv-formatter
-        pip install virtualenv==20.30 # Temporary fix to airspeed-velocity/asv#1484
+      run: pip install asv[virtualenv]==${{env.ASV_VERSION}} lf-asv-formatter
     - name: Make artifacts directory
       run: mkdir -p ${{env.ARTIFACTS_DIR}}
     - name: Save pull request number

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -34,8 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
 {%- if include_benchmarks %}
-    "asv==0.6.4", # Used to compute performance benchmarks
-    "virtualenv==20.30", # Temporary fix to airspeed-velocity/asv#1484
+    "asv[virtualenv]==0.6.5", # Used to compute performance benchmarks
 {%- endif %}
 {%- if 'black'  in enforce_style %}
     "black", # Used for static linting of files


### PR DESCRIPTION
Bump asv to the latest version (0.6.5) and remove virtualenv's max version pin since it’s no longer needed (a fix was introduced in https://github.com/pypa/virtualenv/releases/tag/20.31.2). 

## Checklist

- [X] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [X] This change is linked to an open issue
- [ ] This change includes integration testing, or is small enough to be covered by existing tests