### PR TITLE
Improve list rendering.

### DIFF
--- a/docs/practices/ci_testing.rst
+++ b/docs/practices/ci_testing.rst
@@ -38,18 +38,23 @@ updates is a good place to start. The smoke test has a "List dependencies" stage
 that will print out all packages installed through pip and their installed versions.
 
 1. Find the last successful run of the smoke test
+
    1. github repo -> Actions
    2. "Unit test smoke test"
    3. Scroll until you find a green check
    4. Pick a python versioned build
    5. Expand "List dependencies"
    6. Cut'n'paste the list to a file, e.g. "pass.txt"
+
 2. Find a failed run.
+
    1. From the "Unit test smoke test" page, find the first red check
    2. Pick a python versioned build
    3. Expand "List dependencies"
    4. Cut'n'paste the list to a file, e.g. "fail.txt"
+
 3. Diff those lists
+
    1. e.g. ``diff pass.txt fail.txt``
    2. Or use an online diff tool like https://www.diffchecker.com/
 


### PR DESCRIPTION
## Change Description

Fix rendering of steps used to find version change culprit in nightly smoke tests.

## Checklist

- [x] This PR is meant for the `lincc-frameworks/python-project-template` repo and not a downstream one instead.
- [ ] This change is linked to an open issue
- [x] This change includes integration testing, or is small enough to be covered by existing tests