### PR TITLE
Fix broken smoke tests

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
-sphinx-rtd-theme
+sphinx-rtd-theme>=3.0
 sphinx-copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 dependencies = [
     "setuptools_scm",
     "sphinx", # Used to automatically generate documentation
-    "sphinx-rtd-theme", # Used to render documentation
+    "sphinx-rtd-theme>=3.0", # Used to render documentation
     "sphinx-copybutton",
     "pyyaml-include<3.0",
 ]
@@ -45,7 +45,7 @@ dev = [
     "sphinx",
     "sphinx-autoapi",
     "sphinx-copybutton",
-    "sphinx-rtd-theme",
+    "sphinx-rtd-theme>=3.0",
 ]
 
 [build-system]

--- a/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
+++ b/python-project-template/{% if include_docs %}docs{% endif %}/requirements.txt.jinja
@@ -8,4 +8,4 @@ nbsphinx
 sphinx
 sphinx-autoapi
 sphinx-copybutton
-sphinx-rtd-theme
+sphinx-rtd-theme>=3.0


### PR DESCRIPTION
The smoke tests are failing because the version of sphinx_rtd_theme is incompatible with the newest version of sphinx.