### PR TITLE
Add flake8-print ruff lint for "library"

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -119,6 +119,10 @@ select = [
     "D419",
     # Numpy v2.0 compatibility
     "NPY201",
+    {% if custom_install == 'library' %}
+    # flake8-print
+    "T201",
+    {% endif -%}
 ]
 ignore = [
     "UP006", # Allow non standard library generics in type hints


### PR DESCRIPTION
Sometimes people may accidentally commit `print()` statements to the library code, which is often a bad practice (logging is preferred as we have recently discussed).